### PR TITLE
Add chat badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/ItzCrazyKns/Perplexica/blob/master/LICENSE)
 [![GitHub last commit](https://img.shields.io/github/last-commit/ItzCrazyKns/Perplexica?color=green)](https://github.com/ItzCrazyKns/Perplexica/commits/master)
 [![Discord](https://dcbadge.limes.pink/api/server/26aArMy8tT?style=flat)](https://discord.gg/26aArMy8tT)
+[![Chat with Repo](https://badge.forgithub.com/ItzCrazyKns/Perplexica?badge=chat)](https://uithub.com/ItzCrazyKns/Perplexica)
 
 Perplexica is a **privacy-focused AI answering engine** that runs entirely on your own hardware. It combines knowledge from the vast internet with support for **local LLMs** (Ollama) and cloud providers (OpenAI, Claude, Groq), delivering accurate answers with **cited sources** while keeping your searches completely private.
 


### PR DESCRIPTION
Added a badge for chatting with the repository. Can be useful for people to discover the repo using LLMs.

Looks like this:

[![Chat with Repo](https://badge.forgithub.com/ItzCrazyKns/Perplexica?badge=chat)](https://uithub.com/ItzCrazyKns/Perplexica)

Full disclosure: i'm creator of uithub, an open source way to navigate the context of any repo. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a “Chat with Repo” badge to the README, linking to the repository’s uithub chat so visitors can quickly explore and ask questions.

<sup>Written for commit 604b8beb00346e98a9267693c8d38b95289883f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

