### PR TITLE
fix: consolidate search pipeline robustness fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# Vane — Self-Hosted AI Search Engine
+
+**Fork of:** [ItzCrazyKns/Vane](https://github.com/ItzCrazyKns/Vane) (Perplexica rebrand)
+**Our fork:** [reverb256/Vane](https://github.com/reverb256/Vane)
+**Branch:** `custom-reverb`
+
+## What This Is
+
+Vane provides Perplexity-style AI search with citations, using SearXNG for web search and an LLM for synthesis. We run it as a podman container on nexus (port 30900) behind Caddy (search.lan).
+
+## Why We Forked
+
+Upstream has several known bugs with open PRs that aren't being merged. We cherry-picked and consolidated the fixes into our `custom-reverb` branch:
+
+| Commit | Source | Fix |
+|--------|--------|-----|
+| PR #1094 | octo-patch | `content: null` instead of `content: ''` for assistant tool-call messages |
+| PR #1099 | octo-patch | Error handling in APISearchAgent (prevents hanging requests) |
+| PR #1091 | octo-patch | Null coalescing guards on `.slice()` / `.map()` in search actions |
+| PR #1039 | VibhorGautam | Broad robustness across model providers + SearXNG error handling |
+| Custom | reverb256 | Filter string "undefined" queries from malformed tool calls |
+| Custom | reverb256 | `content ?? ""` null safety in ollama/openai providers |
+| Custom | reverb256 | Type cast for `responses.stream` input (upstream type mismatch) |
+
+## Infrastructure
+
+- **Host:** nexus (podman, host networking)
+- **Port:** 30900 (LAN: search.lan, TLS via Caddy)
+- **Image:** `localhost/vane-custom:latest` (built on nexus from Dockerfile.slim)
+- **SearXNG:** K8s ClusterIP `10.4.98.141:8080`
+- **Data volume:** `/var/lib/vane:/home/vane/data`
+- **NixOS module:** `/etc/nixos/modules/services/vane.nix`
+
+## Build & Deploy
+
+```bash
+# On nexus:
+cd /data/projects/own/vane
+git checkout custom-reverb
+
+# Build the image (~10 min)
+sudo podman build -f Dockerfile.slim -t vane-custom:latest -t vane-custom:v1.12.2-reverb .
+
+# Transfer to root podman storage (systemd runs as root)
+sudo podman save vane-custom:latest | sudo podman load
+
+# Restart
+sudo systemctl restart vane.service
+```
+
+Or use the rebuild script:
+```bash
+./rebuild.sh
+```
+
+## Updating from Upstream
+
+```bash
+cd /data/projects/own/vane
+git fetch upstream
+git checkout custom-reverb
+git rebase upstream/master
+# Resolve conflicts if any, then:
+./rebuild.sh
+```
+
+## NixOS Integration
+
+The NixOS vane module at `/etc/nixos/modules/services/vane.nix` accepts an `image` option.
+Currently set to `"localhost/vane-custom:latest"` in `hosts/nexus/services.nix`.

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,10 @@
+{
+  description = "Vane (Perplexica) — self-hosted AI search engine, reverb256 fork";
+
+  inputs = {};
+
+  outputs = { self }: {
+    # No Nix build — Vane builds via podman (Dockerfile.slim).
+    # This flake exists for project tracking and AGENTS.md conventions.
+  };
+}

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Rebuild vane-custom podman image and reload the systemd service.
+# Run on nexus as j_kro (podman storage is shared via sudo).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "==> Vane custom image rebuild"
+echo "    Branch: $(git branch --show-current)"
+echo "    Last upstream merge: $(git log -1 --format='%h %s' upstream/master 2>/dev/null || echo 'never')"
+echo ""
+
+# Ensure we're on the custom branch
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" != "custom-reverb" ]; then
+    echo "ERROR: Not on custom-reverb branch (current: $BRANCH)"
+    exit 1
+fi
+
+# Build
+echo "==> Building image (this takes ~10 minutes)..."
+sudo podman build \
+    -f Dockerfile.slim \
+    -t vane-custom:latest \
+    -t "vane-custom:v$(grep '"version"' package.json | head -1 | grep -oP '[\d.]+')-reverb" \
+    . 2>&1 | tee /tmp/vane-build.log
+
+if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    echo "ERROR: Build failed. Check /tmp/vane-build.log"
+    exit 1
+fi
+
+echo ""
+echo "==> Build successful. Restarting vane.service..."
+sudo systemctl restart vane.service
+
+sleep 3
+
+# Verify
+IMAGE=$(sudo podman inspect vane --format '{{.Config.Image}}' 2>/dev/null)
+STATUS=$(sudo systemctl is-active vane.service)
+
+echo ""
+echo "==> Done."
+echo "    Image: $IMAGE"
+echo "    Service: $STATUS"

--- a/src/lib/agents/media/video.ts
+++ b/src/lib/agents/media/video.ts
@@ -43,19 +43,31 @@ const searchVideos = async (
     schema: schema,
   });
 
-  const searchRes = await searchSearxng(res.query, {
-    engines: ['youtube'],
-  });
+  let searchRes;
+  try {
+    searchRes = await searchSearxng(res.query, {
+      engines: ['youtube'],
+    });
+  } catch (error) {
+    console.error(`Video search failed for query "${res.query}":`, error);
+    return [];
+  }
 
   const videos: VideoSearchResult[] = [];
 
   searchRes.results.forEach((result) => {
     if (result.thumbnail && result.url && result.title && result.iframe_src) {
+      // Normalize embed URL - some SearXNG instances return
+      // youtube-nocookie.com which doesn't resolve on all networks
+      const embedUrl = result.iframe_src.replace(
+        'www.youtube-nocookie.com/embed',
+        'www.youtube.com/embed',
+      );
       videos.push({
         img_src: result.thumbnail,
         url: result.url,
         title: result.title,
-        iframe_src: result.iframe_src,
+        iframe_src: embedUrl,
       });
     }
   });

--- a/src/lib/agents/search/api.ts
+++ b/src/lib/agents/search/api.ts
@@ -7,6 +7,7 @@ import { WidgetExecutor } from './widgets';
 
 class APISearchAgent {
   async searchAsync(session: SessionManager, input: SearchAgentInput) {
+    try {
     const classification = await classify({
       chatHistory: input.chatHistory,
       enabledSources: input.config.sources,
@@ -96,6 +97,13 @@ class APISearchAgent {
     }
 
     session.emit('end', {});
+    } catch (err) {
+      console.error('API search agent error:', err);
+
+      session.emit('error', {
+        data: err instanceof Error ? err.message : 'An error occurred during search',
+      });
+    }
   }
 }
 

--- a/src/lib/agents/search/researcher/actions/scrapeURL.ts
+++ b/src/lib/agents/search/researcher/actions/scrapeURL.ts
@@ -190,6 +190,7 @@ const scrapeURLAction: ResearchAction<typeof schema> = {
             },
           });
         } catch (error) {
+          console.error(`Failed to scrape URL ${url}:`, error);
           results.push({
             content: `Failed to fetch content from ${url}: ${error}`,
             metadata: {

--- a/src/lib/agents/search/researcher/actions/scrapeURL.ts
+++ b/src/lib/agents/search/researcher/actions/scrapeURL.ts
@@ -65,7 +65,7 @@ const scrapeURLAction: ResearchAction<typeof schema> = {
   getDescription: () => actionDescription,
   enabled: (_) => true,
   execute: async (params, additionalConfig) => {
-    params.urls = params.urls.slice(0, 3);
+    params.urls = (params.urls ?? []).slice(0, 3);
 
     let readingBlockId = crypto.randomUUID();
     let readingEmitted = false;

--- a/src/lib/agents/search/researcher/actions/search/webSearch.ts
+++ b/src/lib/agents/search/researcher/actions/search/webSearch.ts
@@ -89,6 +89,15 @@ const webSearchAction: ResearchAction<typeof actionSchema> = {
       Array.isArray(input.queries) ? input.queries : [input.queries]
     ).slice(0, 3);
 
+    // Guard against undefined/string queries from malformed tool calls
+    input.queries = input.queries.filter(
+      (q) => typeof q === 'string' && q.trim().length > 0
+    );
+
+    if (input.queries.length === 0) {
+      return { type: 'search_results', results: [] };
+    }
+
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,
     ) as ResearchBlock | undefined;

--- a/src/lib/agents/search/researcher/actions/uploadsSearch.ts
+++ b/src/lib/agents/search/researcher/actions/uploadsSearch.ts
@@ -27,7 +27,7 @@ const uploadsSearchAction: ResearchAction<typeof schema> = {
   Never use this tool to search the web or for information that is not contained within the user's uploaded files.
   `,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    input.queries = (input.queries ?? []).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,

--- a/src/lib/agents/search/researcher/index.ts
+++ b/src/lib/agents/search/researcher/index.ts
@@ -157,7 +157,7 @@ class Researcher {
 
       agentMessageHistory.push({
         role: 'assistant',
-        content: '',
+        content: null,
         tool_calls: finalToolCalls,
       });
 

--- a/src/lib/models/providers/ollama/ollamaLLM.ts
+++ b/src/lib/models/providers/ollama/ollamaLLM.ts
@@ -52,7 +52,7 @@ class OllamaLLM extends BaseLLM<OllamaConfig> {
       } else if (msg.role === 'assistant') {
         return {
           role: 'assistant',
-          content: msg.content,
+          content: msg.content ?? "",
           tool_calls:
             msg.tool_calls?.map((tc, i) => ({
               function: {

--- a/src/lib/models/providers/ollama/ollamaLLM.ts
+++ b/src/lib/models/providers/ollama/ollamaLLM.ts
@@ -94,7 +94,9 @@ class OllamaLLM extends BaseLLM<OllamaConfig> {
         temperature:
           input.options?.temperature ?? this.config.options?.temperature ?? 0.7,
         num_predict: input.options?.maxTokens ?? this.config.options?.maxTokens,
-        num_ctx: 32000,
+        num_ctx:
+          input.options?.contextWindowSize ??
+          this.config.options?.contextWindowSize,
         frequency_penalty:
           input.options?.frequencyPenalty ??
           this.config.options?.frequencyPenalty,
@@ -107,15 +109,15 @@ class OllamaLLM extends BaseLLM<OllamaConfig> {
     });
 
     return {
-      content: res.message.content,
+      content: res.message?.content ?? '',
       toolCalls:
-        res.message.tool_calls?.map((tc) => ({
+        res.message?.tool_calls?.map((tc) => ({
           id: crypto.randomUUID(),
           name: tc.function.name,
           arguments: tc.function.arguments,
         })) || [],
       additionalInfo: {
-        reasoning: res.message.thinking,
+        reasoning: res.message?.thinking,
       },
     };
   }
@@ -148,7 +150,9 @@ class OllamaLLM extends BaseLLM<OllamaConfig> {
         top_p: input.options?.topP ?? this.config.options?.topP,
         temperature:
           input.options?.temperature ?? this.config.options?.temperature ?? 0.7,
-        num_ctx: 32000,
+        num_ctx:
+          input.options?.contextWindowSize ??
+          this.config.options?.contextWindowSize,
         num_predict: input.options?.maxTokens ?? this.config.options?.maxTokens,
         frequency_penalty:
           input.options?.frequencyPenalty ??
@@ -163,9 +167,9 @@ class OllamaLLM extends BaseLLM<OllamaConfig> {
 
     for await (const chunk of stream) {
       yield {
-        contentChunk: chunk.message.content,
+        contentChunk: chunk.message?.content ?? '',
         toolCallChunk:
-          chunk.message.tool_calls?.map((tc, i) => ({
+          chunk.message?.tool_calls?.map((tc, i) => ({
             id: crypto
               .createHash('sha256')
               .update(
@@ -177,7 +181,7 @@ class OllamaLLM extends BaseLLM<OllamaConfig> {
           })) || [],
         done: chunk.done,
         additionalInfo: {
-          reasoning: chunk.message.thinking,
+          reasoning: chunk.message?.thinking,
         },
       };
     }

--- a/src/lib/models/providers/openai/openaiLLM.ts
+++ b/src/lib/models/providers/openai/openaiLLM.ts
@@ -102,9 +102,9 @@ class OpenAILLM extends BaseLLM<OpenAIConfig> {
 
     if (response.choices && response.choices.length > 0) {
       return {
-        content: response.choices[0].message.content!,
+        content: response.choices[0].message?.content ?? '',
         toolCalls:
-          response.choices[0].message.tool_calls
+          response.choices[0].message?.tool_calls
             ?.map((tc) => {
               if (tc.type === 'function') {
                 return {

--- a/src/lib/models/providers/openai/openaiLLM.ts
+++ b/src/lib/models/providers/openai/openaiLLM.ts
@@ -50,7 +50,7 @@ class OpenAILLM extends BaseLLM<OpenAIConfig> {
       } else if (msg.role === 'assistant') {
         return {
           role: 'assistant',
-          content: msg.content,
+          content: msg.content ?? "",
           ...(msg.tool_calls &&
             msg.tool_calls.length > 0 && {
               tool_calls: msg.tool_calls?.map((tc) => ({

--- a/src/lib/models/providers/openai/openaiLLM.ts
+++ b/src/lib/models/providers/openai/openaiLLM.ts
@@ -234,7 +234,7 @@ class OpenAILLM extends BaseLLM<OpenAIConfig> {
 
     const stream = this.openAIClient.responses.stream({
       model: this.config.model,
-      input: input.messages,
+      input: input.messages as any,
       temperature:
         input.options?.temperature ?? this.config.options?.temperature ?? 1.0,
       top_p: input.options?.topP ?? this.config.options?.topP,

--- a/src/lib/models/types.ts
+++ b/src/lib/models/types.ts
@@ -35,6 +35,7 @@ type GenerateOptions = {
   stopSequences?: string[];
   frequencyPenalty?: number;
   presencePenalty?: number;
+  contextWindowSize?: number;
 };
 
 type Tool = {

--- a/src/lib/searxng.ts
+++ b/src/lib/searxng.ts
@@ -52,8 +52,8 @@ export const searchSearxng = async (
 
     const data = await res.json();
 
-    const results: SearxngSearchResult[] = data.results;
-    const suggestions: string[] = data.suggestions;
+    const results: SearxngSearchResult[] = data.results ?? [];
+    const suggestions: string[] = data.suggestions ?? [];
 
     return { results, suggestions };
   } catch (err: any) {

--- a/src/lib/searxng.ts
+++ b/src/lib/searxng.ts
@@ -47,7 +47,8 @@ export const searchSearxng = async (
     });
 
     if (!res.ok) {
-      throw new Error(`SearXNG error: ${res.statusText}`);
+      console.error(`SearXNG returned status ${res.status} for query: ${query}`);
+      return { results: [], suggestions: [] };
     }
 
     const data = await res.json();
@@ -58,9 +59,11 @@ export const searchSearxng = async (
     return { results, suggestions };
   } catch (err: any) {
     if (err.name === 'AbortError') {
-      throw new Error('SearXNG search timed out');
+      console.error(`SearXNG search timed out for query: ${query}`);
+      return { results: [], suggestions: [] };
     }
-    throw err;
+    console.error(`SearXNG search failed for query "${query}":`, err);
+    return { results: [], suggestions: [] };
   } finally {
     clearTimeout(timeoutId);
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,7 +7,7 @@ export type SystemMessage = {
 
 export type AssistantMessage = {
   role: 'assistant';
-  content: string;
+  content: string | null;
   tool_calls?: ToolCall[];
 };
 

--- a/src/lib/utils/formatHistory.ts
+++ b/src/lib/utils/formatHistory.ts
@@ -4,7 +4,7 @@ const formatChatHistoryAsString = (history: ChatTurnMessage[]) => {
   return history
     .map(
       (message) =>
-        `${message.role === 'assistant' ? 'AI' : 'User'}: ${message.content}`,
+        `${message.role === 'assistant' ? 'AI' : 'User'}: ${message.content ?? ''}`,
     )
     .join('\n');
 };


### PR DESCRIPTION
## Summary

Consolidates fixes from 4 open PRs (#1017, #1091, #1039, #1094, #1099) plus additional fixes into a single rebased branch against latest master.

## Fixes included

### Search pipeline robustness (from PR #1039 by @VibhorGautam)
- Remove hardcoded `num_ctx: 32000` in Ollama provider — uses `contextWindowSize` from config
- Null-safety on `response.message` in OpenAI and Ollama providers (fixes #836, #789)
- SearXNG error handling — HTTP status checks, try/catch in search actions, early return on empty results (fixes #763)
- Console error logging for scrape/search/SearXNG failures (fixes #997)
- Normalize YouTube embed URLs from youtube-nocookie.com (fixes #799)

### Null coalescing guards (from PR #1091 by @octo-patch)
- `(params.urls ?? []).slice(0, 3)` in scrapeURL
- `(input.queries ?? []).slice(0, 3)` in uploadsSearch
- `data.results ?? []` and `data.suggestions ?? []` in searxng.ts

### Null content for tool-call messages (from PR #1094 by @octo-patch)
- `content: null` instead of `content: ""` for assistant messages with tool_calls
- Prevents OpenAI-compatible provider rejections (fixes #1080)

### API error handling (from PR #1099 by @octo-patch)
- try/catch in APISearchAgent prevents hanging requests
- Returns 500 with error message instead of silent failure

### Additional fixes
- **Query guard in webSearch.ts**: Filters out malformed `undefined` string queries from LLM tool calls before sending to SearXNG. Root cause of "undefined" appearing in search results.
- **Null content in providers**: `msg.content ?? ""` in ollamaLLM.ts and openaiLLM.ts convertToMessages to handle the `content: null` change.
- **SearXNG timeout**: 10s AbortController timeout on SearXNG fetch calls. Returns empty results on timeout instead of hanging.
- **SearXNG graceful error handling**: Returns `{ results: [], suggestions: [] }` on any fetch error instead of throwing.

## Test environment
- Deployed on NixOS with podman (Dockerfile.slim)
- Chat model: Nemotron-Super-49B via NVIDIA NIM
- SearXNG: self-hosted in Kubernetes
- Previously broken: researcher agent sent "undefined" as search query, causing dictionary definition results instead of actual search results. Now returns proper sources.

## Resolves
Fixes #1017, Fixes #1091, Fixes #1039, Fixes #1094, Fixes #1099, Fixes #1080, Fixes #763, Fixes #997, Fixes #836, Fixes #789, Fixes #799

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates and rebases multiple robustness fixes to stabilize the search pipeline and prevent hangs and bad queries across `SearXNG`, `openai`, and `ollama`. Corrects tool-call message format and removes hardcoded context settings for safer provider behavior.

- **Bug Fixes**
  - `SearXNG` stability: 10s timeout with graceful empty results, HTTP status checks, default `results/suggestions` to `[]`, try/catch + logging in web/video searches, and normalization of YouTube `youtube-nocookie` embeds.
  - Tool-calls and queries: set assistant tool-call messages to `content: null`; providers coalesce `msg.content ?? ""` and parse responses with null-safety; guard `.slice()`/`.map()` with `?? []`; filter malformed/empty queries (prevents "undefined" searches) and early-return when none.
  - Providers: remove hardcoded `num_ctx`; respect `contextWindowSize`; null-safe handling in both streamed and non-streamed paths; minor type cast for `responses.stream` input.
  - API: wrap `APISearchAgent.searchAsync` in try/catch and emit error so requests return 500 instead of hanging.

- **New Features**
  - Added `AGENTS.md`, `flake.nix`, and `rebuild.sh` to document infra and streamline podman/systemd rebuilds.

<sup>Written for commit ab26809767a218723f9604595414fd1406e33712. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

