### PR TITLE
fix: fall back to top results when similarity filter removes all SearXNG results

### DIFF
--- a/src/lib/agents/search/researcher/actions/search/baseSearch.ts
+++ b/src/lib/agents/search/researcher/actions/search/baseSearch.ts
@@ -50,26 +50,36 @@ export const executeSearch = async (input: {
       try {
         const queryEmbedding = (await input.embedding.embedText([q]))[0];
 
-        resultChunks = (
-          await Promise.all(
-            res.results.map(async (r) => {
-              const content = r.content || r.title;
-              const chunkEmbedding = (
-                await input.embedding.embedText([content])
-              )[0];
+        const allChunks = await Promise.all(
+          res.results.map(async (r) => {
+            const content = r.content || r.title;
+            const chunkEmbedding = (
+              await input.embedding.embedText([content])
+            )[0];
 
-              return {
-                content,
-                metadata: {
-                  title: r.title,
-                  url: r.url,
-                  similarity: computeSimilarity(queryEmbedding, chunkEmbedding),
-                  embedding: chunkEmbedding,
-                },
-              };
-            }),
-          )
-        ).filter((c) => c.metadata.similarity > 0.5);
+            return {
+              content,
+              metadata: {
+                title: r.title,
+                url: r.url,
+                similarity: computeSimilarity(queryEmbedding, chunkEmbedding),
+                embedding: chunkEmbedding,
+              },
+            };
+          }),
+        );
+
+        resultChunks = allChunks.filter((c) => c.metadata.similarity > 0.5);
+
+        // If the similarity filter removed all results, fall back to the
+        // top results sorted by similarity so external SearXNG instances
+        // where `number_of_results` may be 0 but `results` is non-empty
+        // still produce useful output.
+        if (resultChunks.length === 0 && allChunks.length > 0) {
+          resultChunks = allChunks
+            .sort((a, b) => b.metadata.similarity - a.metadata.similarity)
+            .slice(0, 10);
+        }
       } catch (err) {
         resultChunks = res.results.map((r) => {
           const content = r.content || r.title;


### PR DESCRIPTION
Fixes #1119

In Speed/Balanced mode the similarity filter (>0.5) can discard all SearXNG results for very specific queries, showing 'Found 0 results' even when SearXNG returns a non-empty results array. Quality mode is unaffected because it skips this filter.

Fix: when the similarity filter removes every candidate but raw results exist, fall back to the top 10 results sorted by similarity descending, matching the existing catch-block fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents "Found 0 results" in Speed/Balanced mode by falling back to the top 10 SearXNG results when the similarity filter removes all candidates. Ensures useful output even when SearXNG returns results below the 0.5 threshold.

- **Bug Fixes**
  - If the filtered set is empty but SearXNG returns results, return the top 10 by similarity (desc).
  - Mirrors the existing error-path fallback; Quality mode remains unchanged.

<sup>Written for commit 0e8cb294d4a1d9bd215c27f3f8f9b1eacfa668da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

