### PR TITLE
fix: use raw block data in PDF export to prevent HTML tags in output

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,7 +29,7 @@ const downloadFile = (filename: string, content: string, type: string) => {
 
 const exportAsMarkdown = (sections: Section[], title: string) => {
   const date = new Date(
-    sections[0].message.createdAt || Date.now(),
+    sections[0]?.message?.createdAt || Date.now(),
   ).toLocaleString();
   let md = `# 💬 Chat Export: ${title}\n\n`;
   md += `*Exported on: ${date}*\n\n---\n`;
@@ -142,10 +142,12 @@ const exportAsPDF = (sections: Section[], title: string) => {
       y += 6;
       doc.setTextColor(30);
       doc.setFontSize(12);
-      const assistantLines = doc.splitTextToSize(
-        section.parsedTextBlocks.join('\n'),
-        180,
-      );
+      const rawAssistantText = section.message.responseBlocks
+        .filter((b) => b.type === 'text')
+        .map((block) => block.data)
+        .join('\n')
+        .replace(/<[^>]*>/g, '');
+      const assistantLines = doc.splitTextToSize(rawAssistantText, 180);
       for (let i = 0; i < assistantLines.length; i++) {
         if (y > pageHeight - 20) {
           doc.addPage();

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -142,11 +142,30 @@ const exportAsPDF = (sections: Section[], title: string) => {
       y += 6;
       doc.setTextColor(30);
       doc.setFontSize(12);
+      // Strip citation tags injected by parsedTextBlocks rendering, but
+      // preserve generic-type-style angle brackets (e.g. Vec<T>, List<int>)
+      // and inequalities. Match only HTML-like tags that have either a
+      // multi-letter tag name or attributes — `<T>` and `<i32>` slip
+      // through, `<citation href="...">` and `<div>` get stripped.
+      const HTML_TAG = /<\/?[a-zA-Z][a-zA-Z0-9-]*(?:\s+[^>]*)?\s*\/?>/g;
+      const KNOWN_INJECTED_TAG =
+        /<\/?(?:citation|a|p|div|span|br|hr|strong|em|b|i|u|code|pre|blockquote|h[1-6]|ul|ol|li|table|tr|td|th|thead|tbody|tfoot)\b[^>]*\/?>/gi;
       const rawAssistantText = section.message.responseBlocks
         .filter((b) => b.type === 'text')
         .map((block) => block.data)
         .join('\n')
-        .replace(/<[^>]*>/g, '');
+        .replace(KNOWN_INJECTED_TAG, '')
+        // Catch other HTML-like tags but keep single-letter generics
+        // and digit-only "tags" like <i32>.
+        .replace(HTML_TAG, (match) => {
+          const inner = match.slice(1).replace(/^\//, '').trimStart();
+          // Keep `<T>`, `<i32>` (single-letter or letter-then-digits with
+          // no attributes) — these are almost always generics or types.
+          if (/^[A-Za-z][A-Za-z0-9]*\s*\/?>$/.test(inner) && inner.length <= 5) {
+            return match;
+          }
+          return '';
+        });
       const assistantLines = doc.splitTextToSize(rawAssistantText, 180);
       for (let i = 0; i < assistantLines.length; i++) {
         if (y > pageHeight - 20) {


### PR DESCRIPTION
Fixes #1009

## Problem

The PDF export was reading text from `section.parsedTextBlocks`, which is processed text that contains raw HTML tags injected during rendering:

- Citation links become `<citation href="https://example.com">1</citation>` 
- Thinking blocks add `<think>` / `</think>` wrappers

These tags are intended for the React markdown renderer, but `jsPDF`'s `doc.text()` does not parse HTML — it renders them verbatim in the PDF output.

## Solution

Read the assistant response text directly from `section.message.responseBlocks` (filtering to `type === 'text'`), which is the same source used by the Markdown export. A regex pass strips any residual HTML tags that may remain in the raw block data.

Also adds the missing optional chaining (`sections[0]?.message?.createdAt`) in `exportAsMarkdown` to match the safe pattern already used in `exportAsPDF`.

## Testing

- Open a chat with search results (so citations are present)  
- Click the Share icon → **PDF**  
- Verify the downloaded PDF shows plain readable text instead of `<citation href="...">` markup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PDFs showing HTML by reading assistant text from `responseBlocks` and removing injected tags, while preserving generic/type angle brackets (e.g., `<T>`, `<i32>`). Also makes Markdown export date access safe.

- **Bug Fixes**
  - PDF export now uses `section.message.responseBlocks` (`type === 'text'`) and replaces the old `parsedTextBlocks` source. Strips known injected HTML (e.g., `<citation>`, common HTML tags) and keeps short generic/type tokens like `<T>` and `<i32>`.
  - Added `sections[0]?.message?.createdAt` in Markdown export to avoid unsafe access.

<sup>Written for commit b7759b6bb4bf063b60eee749018fdc4391d23f9d. Summary will update on new commits. <a href="https://cubic.dev/pr/ItzCrazyKns/Vane/pull/1126?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

