### PR TITLE
fix(security): validate URLs in config API to prevent SSRF

### DIFF
--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -15,12 +15,12 @@ function isPrivateOrMetadataUrl(url: string): boolean {
 
     if (
       hostname === 'localhost' ||
-      hostname === '127.0.0.1' ||
       hostname === '0.0.0.0' ||
       hostname === '::1' ||
-      hostname === '169.254.169.254' ||
       hostname === 'metadata.google.internal' ||
       hostname.endsWith('.internal') ||
+      hostname.startsWith('127.') ||
+      hostname.startsWith('169.254.') ||
       hostname.startsWith('10.') ||
       hostname.startsWith('192.168.') ||
       /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname) ||

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -8,6 +8,36 @@ type SaveConfigBody = {
   value: string;
 };
 
+function isPrivateOrMetadataUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname;
+
+    if (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '0.0.0.0' ||
+      hostname === '::1' ||
+      hostname === '169.254.169.254' ||
+      hostname === 'metadata.google.internal' ||
+      hostname.endsWith('.internal') ||
+      hostname.startsWith('10.') ||
+      hostname.startsWith('192.168.') ||
+      /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname) ||
+      /^(fc|fd)[0-9a-f]{2}:/i.test(hostname) ||
+      hostname.startsWith('fe80:')
+    ) {
+      return true;
+    }
+
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+const URL_CONFIG_KEYS = ['search.searxngURL'];
+
 export const GET = async (req: NextRequest) => {
   try {
     const values = configManager.getCurrentConfig();
@@ -50,6 +80,17 @@ export const POST = async (req: NextRequest) => {
       return Response.json(
         {
           message: 'Key and value are required.',
+        },
+        {
+          status: 400,
+        },
+      );
+    }
+
+    if (URL_CONFIG_KEYS.includes(body.key) && isPrivateOrMetadataUrl(body.value)) {
+      return Response.json(
+        {
+          message: 'URL points to a private or internal address. This is not allowed.',
         },
         {
           status: 400,


### PR DESCRIPTION
## Summary

Fixes #1139 — Second-Order SSRF via unprotected config API controlling SearXNG URL.

## Problem

The `POST /api/config` endpoint accepts any URL value without validation. An attacker can set `search.searxngURL` to internal/metadata addresses (`169.254.169.254`, `10.x.x.x`, `localhost`), then trigger server-side requests via `/api/discover` that hit internal infrastructure.

## Fix

Add `isPrivateOrMetadataUrl()` validation that rejects:
- Localhost (`127.0.0.1`, `::1`, `localhost`)
- AWS/GCP metadata endpoints (`169.254.169.254`, `metadata.google.internal`)
- RFC 1918 private ranges (`10.x`, `172.16-31.x`, `192.168.x`)
- IPv6 link-local and ULA (`fe80:`, `fc/fd`)
- Any `.internal` TLD

Applied only to config keys that store URLs (`search.searxngURL`).

## Notes

- This is a defense-in-depth measure. Ideally the config API should also require authentication (separate concern, separate PR).
- Does not break legitimate SearXNG URLs (public domains pass validation).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate URL inputs in the config API to block SSRF. Prevents setting `search.searxngURL` to private, loopback, link‑local, or metadata addresses, addressing #1139.

- **Bug Fixes**
  - Added `isPrivateOrMetadataUrl()` and applied to `search.searxngURL`; blocked URLs return 400 with a clear error.
  - Blocks `localhost`/`0.0.0.0`, 127.0.0.0/8, 169.254.0.0/16, RFC1918 ranges, IPv6 `::1` and link‑local/ULA, `.internal`, and `metadata.google.internal`.

<sup>Written for commit a4ba291b06ff3283c5e76b122e7c1d7b7e4c4b8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ItzCrazyKns/Vane/pull/1145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

