### PR TITLE
Fix OpenRouter streaming tool-call argument parsing

### DIFF
--- a/docs/RUN_LOCAL_VI.md
+++ b/docs/RUN_LOCAL_VI.md
@@ -1,0 +1,280 @@
+# Chay Vane local tren Windows
+
+File nay ghi cach tu chay project Vane trong repo nay.
+
+## 1. Yeu cau
+
+- Windows + PowerShell
+- Node.js da cai san
+- npm da cai san
+- Repo nam tai:
+
+```powershell
+C:\Users\Admin\Desktop\GIT CLONE\Vane
+```
+
+Kiem tra Node/npm:
+
+```powershell
+node -v
+npm -v
+```
+
+## 2. Vao thu muc project
+
+```powershell
+cd "C:\Users\Admin\Desktop\GIT CLONE\Vane"
+```
+
+## 3. Cai dependencies
+
+Neu `node_modules` chua co, chay:
+
+```powershell
+npm install
+```
+
+Neu `node_modules` da co, co the bo qua buoc nay.
+
+## 4. Chay development server
+
+```powershell
+npm run dev
+```
+
+Neu thanh cong, terminal se hien dai loai:
+
+```text
+Next.js 16.2.2 (Turbopack)
+- Local: http://localhost:3000
+Ready
+```
+
+Mo trinh duyet:
+
+```text
+http://localhost:3000
+```
+
+## 5. Chay production local
+
+Dung khi muon test gan voi deploy hon:
+
+```powershell
+npm run build
+npm run start
+```
+
+Mo:
+
+```text
+http://localhost:3000
+```
+
+## 6. Cau hinh Vane
+
+Vane luu cau hinh tai:
+
+```text
+data/config.json
+```
+
+Cac field quan trong:
+
+```json
+{
+  "setupComplete": true,
+  "modelProviders": [],
+  "search": {
+    "searxngURL": ""
+  }
+}
+```
+
+Neu `setupComplete` la `false`, Vane se hien setup wizard.
+Neu `setupComplete` la `true`, Vane vao thang chat.
+
+## 7. Cau hinh OpenRouter/DeepSeek
+
+Provider OpenRouter dung provider type `openai`, vi OpenRouter tuong thich OpenAI API.
+
+Base URL:
+
+```text
+https://openrouter.ai/api/v1
+```
+
+Model chat:
+
+```text
+deepseek/deepseek-v4-flash
+```
+
+Vi du provider trong `data/config.json`:
+
+```json
+{
+  "id": "openrouter-deepseek",
+  "name": "OpenRouter DeepSeek",
+  "type": "openai",
+  "config": {
+    "apiKey": "YOUR_OPENROUTER_API_KEY",
+    "baseURL": "https://openrouter.ai/api/v1"
+  },
+  "chatModels": [
+    {
+      "name": "DeepSeek V4 Flash",
+      "key": "deepseek/deepseek-v4-flash"
+    }
+  ],
+  "embeddingModels": [],
+  "hash": "openrouter-deepseek-manual"
+}
+```
+
+Khong commit API key len Git.
+Neu API key tung bi lo, revoke key cu va tao key moi tren OpenRouter.
+
+## 8. Cau hinh embedding local
+
+Vane can embedding model cho search/upload/RAG. Co the dung Transformers local:
+
+```json
+{
+  "id": "local-transformers-embeddings",
+  "name": "Transformers",
+  "type": "transformers",
+  "config": {},
+  "chatModels": [],
+  "embeddingModels": [
+    {
+      "name": "all-MiniLM-L6-v2",
+      "key": "Xenova/all-MiniLM-L6-v2"
+    }
+  ],
+  "hash": "local-transformers-manual"
+}
+```
+
+Lan dau dung embedding model co the can tai model tu HuggingFace. Neu mang bi chan, embedding co the loi.
+
+## 9. Cau hinh SearXNG de search web
+
+Neu chi chat voi model, co the de trong:
+
+```json
+"search": {
+  "searxngURL": ""
+}
+```
+
+Neu muon web search/discover, can SearXNG chay rieng va set URL, vi du:
+
+```json
+"search": {
+  "searxngURL": "http://localhost:4000"
+}
+```
+
+SearXNG can bat JSON output trong settings.
+
+## 10. Restart app sau khi sua config
+
+Sau khi sua `data/config.json`, can restart server.
+
+Dung `Ctrl + C` trong terminal dang chay `npm run dev`, roi chay lai:
+
+```powershell
+npm run dev
+```
+
+Neu server dang chay ngam va port 3000 bi chiem:
+
+```powershell
+netstat -ano | findstr :3000
+```
+
+Lay PID cuoi dong `LISTENING`, roi stop:
+
+```powershell
+Stop-Process -Id <PID> -Force
+```
+
+Sau do chay lai:
+
+```powershell
+npm run dev
+```
+
+## 11. Loi thuong gap
+
+### Setup cu hien lai
+
+Kiem tra:
+
+```powershell
+Get-Content data\config.json
+```
+
+Dam bao:
+
+```json
+"setupComplete": true
+```
+
+Neu file JSON loi, Vane co the overwrite ve default. Hay dam bao file la JSON hop le va UTF-8 khong BOM.
+
+### Loi `Invalid URL` o `/api/discover`
+
+Nguyen nhan: `search.searxngURL` dang rong.
+
+Fix: cau hinh SearXNG URL, hoac khong dung trang Discover/web search.
+
+### Khong co chat model
+
+Kiem tra `modelProviders` co provider chat khong:
+
+```powershell
+Invoke-WebRequest http://localhost:3000/api/providers -UseBasicParsing
+```
+
+Can it nhat 1 provider co `chatModels`.
+
+### Khong co embedding model
+
+Can it nhat 1 provider co `embeddingModels`, thuong la Transformers local.
+
+### Git bao dubious ownership
+
+Neu can dung git trong repo:
+
+```powershell
+git config --global --add safe.directory "C:/Users/Admin/Desktop/GIT CLONE/Vane"
+```
+
+## 12. Lenh nhanh
+
+Chay dev:
+
+```powershell
+cd "C:\Users\Admin\Desktop\GIT CLONE\Vane"
+npm run dev
+```
+
+Build production:
+
+```powershell
+npm run build
+```
+
+Start production sau build:
+
+```powershell
+npm run start
+```
+
+Mo app:
+
+```text
+http://localhost:3000
+```

--- a/src/components/MessageBox.tsx
+++ b/src/components/MessageBox.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /* eslint-disable @next/next/no-img-element */
-import React, { MutableRefObject } from 'react';
+import React, { MutableRefObject, useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 import {
   BookCopy,
@@ -26,6 +26,44 @@ import AssistantSteps from './AssistantSteps';
 import { ResearchBlock } from '@/lib/types';
 import Renderer from './Widgets/Renderer';
 import CodeBlock from './MessageRenderer/CodeBlock';
+
+
+const BrainstormingStatus = () => {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    const startedAt = Date.now();
+    const timer = window.setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const phase =
+    elapsed < 8
+      ? 'Preparing models and classifying your question...'
+      : elapsed < 20
+        ? 'Planning research steps. If web search is enabled, Vane may be waiting for SearXNG or the model API.'
+        : elapsed < 45
+          ? 'Still working. Long waits usually mean the model API, embedding model download, or SearXNG is slow.'
+          : 'This is taking unusually long. Check terminal logs, OpenRouter key, and SearXNG URL.';
+
+  return (
+    <div className="flex flex-col gap-2 p-3 rounded-lg bg-light-secondary dark:bg-dark-secondary border border-light-200 dark:border-dark-200">
+      <div className="flex items-center gap-2">
+        <Disc3 className="w-4 h-4 text-black dark:text-white animate-spin" />
+        <span className="text-sm font-medium text-black dark:text-white">
+          Brainstorming... {elapsed}s
+        </span>
+      </div>
+      <p className="text-xs text-black/60 dark:text-white/60">{phase}</p>
+      <p className="text-[11px] text-black/45 dark:text-white/45">
+        Once research starts, the Research Progress panel will show active queries and sources being read.
+      </p>
+    </div>
+  );
+};
 
 const ThinkTagProcessor = ({
   children,
@@ -149,12 +187,7 @@ const MessageBox = ({
             !section.message.responseBlocks.some(
               (b) => b.type === 'research' && b.data.subSteps.length > 0,
             ) && (
-              <div className="flex items-center gap-2 p-3 rounded-lg bg-light-secondary dark:bg-dark-secondary border border-light-200 dark:border-dark-200">
-                <Disc3 className="w-4 h-4 text-black dark:text-white animate-spin" />
-                <span className="text-sm text-black/70 dark:text-white/70">
-                  Brainstorming...
-                </span>
-              </div>
+<BrainstormingStatus />
             )}
 
           {section.widgets.length > 0 && <Renderer widgets={section.widgets} />}

--- a/src/lib/models/providers/openai/openaiLLM.ts
+++ b/src/lib/models/providers/openai/openaiLLM.ts
@@ -161,30 +161,50 @@ class OpenAILLM extends BaseLLM<OpenAIConfig> {
     let recievedToolCalls: { name: string; id: string; arguments: string }[] =
       [];
 
+    const parseToolArguments = (argumentsText: string) => {
+      if (!argumentsText.trim()) return {};
+
+      try {
+        return parse(argumentsText);
+      } catch (err) {
+        // Some OpenAI-compatible providers stream an empty or partial arguments
+        // chunk before the full JSON arrives. Keep streaming instead of failing.
+        return {};
+      }
+    };
+
     for await (const chunk of stream) {
       if (chunk.choices && chunk.choices.length > 0) {
         const toolCalls = chunk.choices[0].delta.tool_calls;
         yield {
           contentChunk: chunk.choices[0].delta.content || '',
           toolCallChunk:
-            toolCalls?.map((tc) => {
-              if (!recievedToolCalls[tc.index]) {
-                const call = {
-                  name: tc.function?.name!,
-                  id: tc.id!,
-                  arguments: tc.function?.arguments || '',
-                };
-                recievedToolCalls.push(call);
-                return { ...call, arguments: parse(call.arguments || '{}') };
-              } else {
+            toolCalls
+              ?.map((tc) => {
                 const existingCall = recievedToolCalls[tc.index];
+
+                if (!existingCall) {
+                  if (!tc.id || !tc.function?.name) return undefined;
+
+                  const call = {
+                    name: tc.function.name,
+                    id: tc.id,
+                    arguments: tc.function.arguments || '',
+                  };
+                  recievedToolCalls[tc.index] = call;
+                  return {
+                    ...call,
+                    arguments: parseToolArguments(call.arguments),
+                  };
+                }
+
                 existingCall.arguments += tc.function?.arguments || '';
                 return {
                   ...existingCall,
-                  arguments: parse(existingCall.arguments),
+                  arguments: parseToolArguments(existingCall.arguments),
                 };
-              }
-            }) || [],
+              })
+              .filter((tc) => tc !== undefined) || [],
           done: chunk.choices[0].finish_reason !== null,
           additionalInfo: {
             finishReason: chunk.choices[0].finish_reason,


### PR DESCRIPTION
﻿## What this changes

- Fixes a crash in `src/lib/models/providers/openai/openaiLLM.ts` when OpenAI-compatible providers stream empty or partial tool-call arguments.
- Makes the pre-research `Brainstorming...` fallback more informative by showing elapsed time and likely wait reasons.
- Adds a Vietnamese local run guide in `docs/RUN_LOCAL_VI.md`.

## Why

OpenRouter-compatible providers can stream tool-call `arguments` incrementally. The previous parser tried to parse every partial chunk immediately and could throw `Error: is empty`, leaving the UI stuck in `Brainstorming...`.

## Validation

- `npx tsc --noEmit --pretty false`
- Manually verified local Vane startup
- Manually verified local SearXNG JSON endpoint

## Notes

This PR intentionally includes only:

- `src/lib/models/providers/openai/openaiLLM.ts`
- `src/components/MessageBox.tsx`
- `docs/RUN_LOCAL_VI.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when OpenAI-compatible providers (e.g., OpenRouter) stream empty or partial tool-call arguments, and makes the “Brainstorming…” state more informative. Adds a Vietnamese local run guide.

- **Bug Fixes**
  - Handle streamed tool-call `arguments` incrementally and ignore empty/partial chunks instead of throwing. Prevents UI hang on “Brainstorming…”.

- **New Features**
  - “Brainstorming…” shows elapsed time and likely wait reasons.
  - Adds `docs/RUN_LOCAL_VI.md` for Vietnamese local setup.

<sup>Written for commit 939e717cce3ea49325d22afe809dcac46d27f74f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ItzCrazyKns/Vane/pull/1151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

