### PR TITLE
feat: add fastCRW search provider

### DIFF
--- a/src/lib/agents/search/researcher/actions/search/baseSearch.ts
+++ b/src/lib/agents/search/researcher/actions/search/baseSearch.ts
@@ -1,6 +1,8 @@
 import BaseEmbedding from '@/lib/models/base/embedding';
 import BaseLLM from '@/lib/models/base/llm';
 import { searchSearxng, SearxngSearchOptions } from '@/lib/searxng';
+import { searchCrw } from '@/lib/crw';
+import { getSearchProvider } from '@/lib/config/serverRegistry';
 import SessionManager from '@/lib/session';
 import { Chunk, ResearchBlock, SearchResultsResearchBlock } from '@/lib/types';
 import { SearchAgentConfig } from '../../../types';
@@ -8,6 +10,17 @@ import computeSimilarity from '@/lib/utils/computeSimilarity';
 import z from 'zod';
 import Scraper from '@/lib/scraper';
 import { splitText } from '@/lib/utils/splitText';
+
+/*
+ * Dispatches a general web search to the configured provider. Defaults to
+ * SearXNG; fastCRW (Firecrawl-compatible) is selectable via search config.
+ */
+const searchWeb = async (query: string, opts?: SearxngSearchOptions) => {
+  if (getSearchProvider() === 'crw') {
+    return searchCrw(query);
+  }
+  return searchSearxng(query, opts);
+};
 
 export const executeSearch = async (input: {
   queries: string[];
@@ -41,7 +54,7 @@ export const executeSearch = async (input: {
     const results: Chunk[] = [];
 
     const search = async (q: string) => {
-      const res = await searchSearxng(q, {
+      const res = await searchWeb(q, {
         ...(input.searchConfig ? input.searchConfig : {}),
       });
 
@@ -176,7 +189,7 @@ export const executeSearch = async (input: {
     const searchResults: Chunk[] = [];
 
     const search = async (q: string) => {
-      const res = await searchSearxng(q, {
+      const res = await searchWeb(q, {
         ...(input.searchConfig ? input.searchConfig : {}),
       });
 

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -17,7 +17,10 @@ class ConfigManager {
     personalization: {},
     modelProviders: [],
     search: {
+      searchProvider: 'searxng',
       searxngURL: '',
+      crwURL: 'https://fastcrw.com/api',
+      crwApiKey: '',
     },
   };
   uiConfigSections: UIConfigSections = {
@@ -103,6 +106,26 @@ class ConfigManager {
     modelProviders: [],
     search: [
       {
+        name: 'Search Provider',
+        key: 'searchProvider',
+        type: 'select',
+        options: [
+          {
+            name: 'SearXNG',
+            value: 'searxng',
+          },
+          {
+            name: 'fastCRW',
+            value: 'crw',
+          },
+        ],
+        required: false,
+        description: 'The backend used for general web search.',
+        default: 'searxng',
+        scope: 'server',
+        env: 'SEARCH_PROVIDER',
+      },
+      {
         name: 'SearXNG URL',
         key: 'searxngURL',
         type: 'string',
@@ -112,6 +135,30 @@ class ConfigManager {
         default: '',
         scope: 'server',
         env: 'SEARXNG_API_URL',
+      },
+      {
+        name: 'fastCRW URL',
+        key: 'crwURL',
+        type: 'string',
+        required: false,
+        description:
+          'The base URL of fastCRW (Firecrawl-compatible web scraper; single binary, self-host or cloud)',
+        placeholder: 'https://fastcrw.com/api',
+        default: 'https://fastcrw.com/api',
+        scope: 'server',
+        env: 'CRW_API_URL',
+      },
+      {
+        name: 'fastCRW API Key',
+        key: 'crwApiKey',
+        type: 'password',
+        required: false,
+        description:
+          'Bearer API key for fastCRW cloud (leave empty for keyless self-host)',
+        placeholder: 'fc-...',
+        default: '',
+        scope: 'server',
+        env: 'CRW_API_KEY',
       },
     ],
   };

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -17,9 +17,9 @@ class ConfigManager {
     personalization: {},
     modelProviders: [],
     search: {
-      searchProvider: 'searxng',
+      searchProvider: '',
       searxngURL: '',
-      crwURL: 'https://fastcrw.com/api',
+      crwURL: '',
       crwApiKey: '',
     },
   };

--- a/src/lib/config/serverRegistry.ts
+++ b/src/lib/config/serverRegistry.ts
@@ -13,3 +13,11 @@ export const getConfiguredModelProviderById = (
 
 export const getSearxngURL = () =>
   configManager.getConfig('search.searxngURL', '');
+
+export const getCrwURL = () =>
+  configManager.getConfig('search.crwURL', 'https://fastcrw.com/api');
+
+export const getCrwApiKey = () => configManager.getConfig('search.crwApiKey', '');
+
+export const getSearchProvider = () =>
+  configManager.getConfig('search.searchProvider', 'searxng');

--- a/src/lib/crw.test.ts
+++ b/src/lib/crw.test.ts
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { searchCrw } from './crw';
+
+/*
+ * No-network unit test for the fastCRW search provider. Mirrors the shape of
+ * the SearXNG provider: searchCrw() returns { results, suggestions }. fetch is
+ * stubbed so the test never hits the network.
+ */
+
+const withMockedFetch = async (
+  impl: (input: any, init: any) => Promise<Response> | Response,
+  run: () => Promise<void>,
+) => {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl as unknown as typeof fetch;
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = original;
+  }
+};
+
+test('searchCrw posts to /v1/search and maps results', async () => {
+  let calledUrl = '';
+  let calledInit: any = null;
+
+  await withMockedFetch(
+    (input, init) => {
+      calledUrl = input.toString();
+      calledInit = init;
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: [
+            {
+              title: 'Example',
+              url: 'https://example.com',
+              description: 'An example result',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    },
+    async () => {
+      const { results, suggestions } = await searchCrw('hello world', {
+        limit: 5,
+      });
+
+      assert.ok(calledUrl.endsWith('/v1/search'));
+      assert.equal(calledInit.method, 'POST');
+      assert.deepEqual(JSON.parse(calledInit.body), {
+        query: 'hello world',
+        limit: 5,
+      });
+
+      assert.equal(results.length, 1);
+      assert.equal(results[0].title, 'Example');
+      assert.equal(results[0].url, 'https://example.com');
+      assert.equal(results[0].content, 'An example result');
+      assert.deepEqual(suggestions, []);
+    },
+  );
+});
+
+test('searchCrw throws on an unsuccessful envelope', async () => {
+  await withMockedFetch(
+    () =>
+      new Response(
+        JSON.stringify({ success: false, error: 'bad request' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    async () => {
+      await assert.rejects(() => searchCrw('boom'), /fastCRW error: bad request/);
+    },
+  );
+});
+
+test('searchCrw throws on a non-ok response', async () => {
+  await withMockedFetch(
+    () => new Response('nope', { status: 500, statusText: 'Server Error' }),
+    async () => {
+      await assert.rejects(() => searchCrw('boom'), /fastCRW error/);
+    },
+  );
+});

--- a/src/lib/crw.ts
+++ b/src/lib/crw.ts
@@ -1,0 +1,90 @@
+import { getCrwURL, getCrwApiKey } from './config/serverRegistry';
+
+export interface CrwSearchOptions {
+  limit?: number;
+  sources?: string[];
+}
+
+interface CrwSearchResult {
+  title: string;
+  url: string;
+  content?: string;
+  markdown?: string;
+}
+
+/* Raw /v1/search result item as returned by the fastCRW API. */
+interface CrwApiSearchResult {
+  title: string;
+  url: string;
+  description?: string;
+  markdown?: string;
+}
+
+/*
+ * fastCRW is a Firecrawl-compatible web data engine (single Rust binary;
+ * self-host or cloud). This mirrors searchSearxng and returns the same shape
+ * by mapping fastCRW's /v1/search results onto SearXNG-style results.
+ */
+export const searchCrw = async (query: string, opts?: CrwSearchOptions) => {
+  const crwURL = getCrwURL();
+  const crwApiKey = getCrwApiKey();
+
+  const url = new URL(`${crwURL}/v1/search`);
+
+  const body: { query: string; limit?: number; sources?: string[] } = {
+    query,
+  };
+
+  if (opts) {
+    if (opts.limit !== undefined) body.limit = opts.limit;
+    if (opts.sources !== undefined) body.sources = opts.sources;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (crwApiKey) {
+      headers['Authorization'] = `Bearer ${crwApiKey}`;
+    }
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      throw new Error(`fastCRW error: ${res.statusText}`);
+    }
+
+    const data = await res.json();
+
+    if (data.success === false) {
+      throw new Error(`fastCRW error: ${data.error ?? 'unknown error'}`);
+    }
+
+    const results: CrwSearchResult[] = (data.data ?? []).map(
+      (r: CrwApiSearchResult) => ({
+        title: r.title,
+        url: r.url,
+        content: r.description,
+        markdown: r.markdown,
+      }),
+    );
+    const suggestions: string[] = [];
+
+    return { results, suggestions };
+  } catch (err: any) {
+    if (err.name === 'AbortError') {
+      throw new Error('fastCRW search timed out');
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};


### PR DESCRIPTION
## What
Adds **fastCRW** as a selectable search provider, alongside SearXNG (and the upcoming Tavily/Exa).

## Why

[fastCRW](https://fastcrw.com) is a self-hostable web crawl/search engine that ships as a **single ~8MB Rust binary** using ~6MB RAM. Here's what makes it meaningfully different from existing options:

- **Runs 100% locally with no capability gaps.** Anti-bot/stealth handling, JS rendering (including Cloudflare challenges + SPA support), UA rotation, and BYO-proxy + rotation all ship in the open core (AGPL). There are no cloud-only flags, no degraded self-host mode, no asterisks.
- **Outperforms on Firecrawl's own benchmark dataset.** fastCRW achieves **63.74% truth-recall vs Firecrawl's 56.04%**, with faster median latency (**p50 ~1.9s vs ~2.3s**) — measured on Firecrawl's published evaluation set.
- **Search = SearXNG underneath, with a quality layer on top.** crw is not an alternative to SearXNG — it is built on top of it. SearXNG is the metasearch aggregator; crw adds query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content instead of SearXNG's content-blind ordering), a calibrated direct-answer mode, and category routing (research queries fan out to arxiv / semantic scholar / google scholar, code queries to GitHub). You get SearXNG's breadth plus a measurable accuracy layer — all AGPL and self-hostable with configurable engines. Flat 1 credit = 1 page pricing on the managed path; no stealth surcharge, no billed-on-failure.

### What this means for Vane users

Vane + fastCRW is one of the only combinations where self-hosting actually delivers complete, Cloudflare-bypassing search — not a degraded subset of a managed product. One binary, AGPL, no external services required.

For the managed path: flat 1 credit = 1 page pricing, no stealth surcharge, no billed-on-failure.

The integration diff is small because fastCRW exposes a Firecrawl-compatible API — that's the only role compatibility plays here; it's not the value prop.

## Changes (additive only)
- `src/lib/crw.ts` (+ `crw.test.ts`): `searchCrw()` mirroring `searxng.ts`.
- `src/lib/config/index.ts` + `config/serverRegistry.ts`: CRW config getters mirroring the SearXNG ones.
- `src/.../actions/search/baseSearch.ts`: registers `crw` as a provider branch.

`CRW_API_KEY` from https://fastcrw.com/dashboard (free tier); self-host base URL supported. Happy to adjust — I maintain it and can provide free credits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `fastCRW` as a selectable web search provider with a new `searchCrw()` path; `searxng` remains the default. Also ensures `SEARCH_PROVIDER` and `CRW_API_URL` env vars take effect on fresh configs.

- **New Features**
  - Provider selection via `search.searchProvider` (`searxng` or `crw`).
  - New config/envs: `search.crwURL` (`CRW_API_URL`, default `https://fastcrw.com/api`), `search.crwApiKey` (`CRW_API_KEY`).
  - Implemented `searchCrw()` for `/v1/search` with result mapping and 10s timeout; added unit tests.
  - Researcher `baseSearch` dispatches to `searchCrw()` when `crw` is selected.

- **Bug Fixes**
  - Env overrides for `SEARCH_PROVIDER` and `CRW_API_URL` are applied on fresh config.

<sup>Written for commit 5f069120a9b14b0ce36322d0f74d9a67390b1513. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ItzCrazyKns/Vane/pull/1152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
