### PR TITLE
feat(helm): add Helm chart for Kubernetes deployment

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -39,3 +39,6 @@ coverage
 
 # Ignore all files in uploads directory
 uploads
+
+# Ignore Helm chart templates (Go templating conflicts with Prettier)
+charts/**/templates

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Want to know more about its architecture and how it works? You can read it [here
 Vane's development is powered by the generous support of our sponsors. Their contributions help keep this project free, open-source, and accessible to everyone.
 
 <div align="center">
-  
-  
+
 <a href="https://www.warp.dev/perplexica">
   <img alt="Warp Terminal" src=".assets/sponsers/warp.png" width="100%">
 </a>
@@ -128,6 +127,23 @@ If you prefer to build from source or need more control:
 5. Access Vane at http://localhost:3000 and configure your settings in the setup screen.
 
 **Note**: After the containers are built, you can start Vane directly from Docker without having to open a terminal.
+
+### Kubernetes (Helm)
+
+A Helm chart is available in [`charts/vane`](charts/vane) to deploy Vane on Kubernetes. It supports both official images through a single `variant` switch:
+
+- `variant=full` (default) deploys `itzcrazykns1337/vane:latest` with the bundled SearxNG - no extra setup required.
+- `variant=slim` deploys `itzcrazykns1337/vane:slim-latest` and either deploys a SearxNG instance for you (`searxng.deploy=true`) or points at an existing one (`searxng.url`).
+
+```bash
+# Full image (Vane + bundled SearxNG)
+helm install vane ./charts/vane
+
+# Slim image with a chart-managed SearxNG
+helm install vane ./charts/vane --set variant=slim --set searxng.deploy=true
+```
+
+See the [chart README](charts/vane/README.md) for the full list of options (persistence, ingress, providers, etc.).
 
 ### Non-Docker Installation
 

--- a/charts/vane/.helmignore
+++ b/charts/vane/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/vane/Chart.yaml
+++ b/charts/vane/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: vane
+description: A privacy-focused AI answering engine that runs entirely on your own hardware
+type: application
+# Chart version. Bump on every change to the chart itself.
+version: 0.1.0
+# Version of Vane shipped by default. Matches the app version in package.json.
+appVersion: '1.12.2'
+home: https://github.com/ItzCrazyKns/Vane
+icon: https://raw.githubusercontent.com/ItzCrazyKns/Vane/master/public/icon-100.png
+sources:
+  - https://github.com/ItzCrazyKns/Vane
+keywords:
+  - ai
+  - search
+  - search-engine
+  - answering-engine
+  - llm
+  - rag
+  - searxng
+  - privacy
+maintainers:
+  - name: Vane contributors
+    url: https://github.com/ItzCrazyKns/Vane

--- a/charts/vane/README.md
+++ b/charts/vane/README.md
@@ -1,0 +1,129 @@
+# Vane Helm Chart
+
+A Helm chart to deploy [Vane](https://github.com/ItzCrazyKns/Vane) — a
+privacy-focused AI answering engine — on Kubernetes.
+
+The chart ships both official images through a single `variant` switch:
+
+| `variant` | Image                              | SearXNG                                              |
+| --------- | ---------------------------------- | ---------------------------------------------------- |
+| `full`    | `itzcrazykns1337/vane:latest`      | Bundled inside the image (no extra setup)            |
+| `slim`    | `itzcrazykns1337/vane:slim-latest` | External — deployed by this chart or provided by you |
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.x
+- A default `StorageClass` (or set `persistence.*.storageClass`) for the
+  persistent volumes that hold Vane's config, database and uploads.
+
+## Installing
+
+From a checkout of the repository:
+
+```bash
+# Full image (Vane + bundled SearXNG) — the recommended default
+helm install vane ./charts/vane
+
+# Slim image, letting the chart deploy SearXNG for you
+helm install vane ./charts/vane \
+  --set variant=slim \
+  --set searxng.deploy=true
+
+# Slim image, using an existing SearXNG instance
+helm install vane ./charts/vane \
+  --set variant=slim \
+  --set searxng.deploy=false \
+  --set searxng.url=http://my-searxng.example.com:8080
+```
+
+After the pod is ready, port-forward (or use your Ingress) and finish setup in
+the UI — API keys, models and, if needed, the search backend URL:
+
+```bash
+kubectl port-forward svc/vane 3000:3000
+# open http://127.0.0.1:3000
+```
+
+## Choosing a variant
+
+- **`full` (default)** — `itzcrazykns1337/vane:latest` bundles SearXNG in the
+  same container. It is the simplest option and mirrors the recommended Docker
+  setup. `searxng.*` values are ignored.
+- **`slim`** — `itzcrazykns1337/vane:slim-latest` contains only Vane. You must
+  provide a SearXNG backend:
+  - `searxng.deploy=true` (default for slim): the chart deploys a SearXNG
+    `Deployment` + `Service` + `Secret` (configured with JSON format and the
+    Wolfram Alpha engine enabled, as Vane requires) and wires
+    `SEARXNG_API_URL` automatically.
+  - `searxng.deploy=false`: set `searxng.url` to an existing SearXNG instance.
+    That instance must have the JSON format and Wolfram Alpha engine enabled.
+
+The image tag is derived from `variant` automatically (`latest` /
+`slim-latest`). Override it with `image.tag` to pin a specific release such as
+`1.12.2` or `slim-1.12.2`.
+
+## Persistence
+
+Vane keeps its configuration (`config.json`) and history (`db.sqlite`) in
+`/home/vane/data`, and uploaded files in `/home/vane/uploads`. Both are backed
+by `PersistentVolumeClaim`s by default:
+
+| Volume    | Mount path           | Default size | Value                   |
+| --------- | -------------------- | ------------ | ----------------------- |
+| `data`    | `/home/vane/data`    | `2Gi`        | `persistence.data.*`    |
+| `uploads` | `/home/vane/uploads` | `5Gi`        | `persistence.uploads.*` |
+
+Because the database is a local SQLite file on a `ReadWriteOnce` volume, keep
+`replicaCount: 1` (the default) unless you supply a `ReadWriteMany` volume.
+
+## Configuration
+
+The most relevant values (see [`values.yaml`](./values.yaml) for the full list):
+
+| Key                        | Description                                                      | Default                |
+| -------------------------- | ---------------------------------------------------------------- | ---------------------- |
+| `variant`                  | `full` or `slim`                                                 | `full`                 |
+| `image.repository`         | Vane image repository                                            | `itzcrazykns1337/vane` |
+| `image.tag`                | Overrides the tag derived from `variant`                         | `''`                   |
+| `replicaCount`             | Number of Vane replicas                                          | `1`                    |
+| `vane.env`                 | Extra env vars (e.g. provider API keys, `DATA_DIR`)              | `{}`                   |
+| `vane.envFrom`             | Extra env vars from existing ConfigMaps/Secrets                  | `[]`                   |
+| `searxng.deploy`           | (slim) Deploy an in-cluster SearXNG and wire it automatically    | `true`                 |
+| `searxng.url`              | (slim) External SearXNG URL, used when `searxng.deploy=false`    | `''`                   |
+| `searxng.image.repository` | SearXNG image repository                                         | `searxng/searxng`      |
+| `searxng.secretKey`        | SearXNG `secret_key`; auto-generated (and kept stable) if empty  | `''`                   |
+| `service.type`             | Vane Service type                                                | `ClusterIP`            |
+| `service.port`             | Vane Service port                                                | `3000`                 |
+| `ingress.enabled`          | Enable an Ingress for Vane                                       | `false`                |
+| `persistence.data.size`    | Size of the config/database volume                               | `2Gi`                  |
+| `persistence.uploads.size` | Size of the uploads volume                                       | `5Gi`                  |
+| `resources`                | Resource requests/limits for Vane                                | `{}`                   |
+| `autoscaling.enabled`      | Enable a HorizontalPodAutoscaler (not advised with local SQLite) | `false`                |
+
+### Configuring providers via environment variables
+
+Vane can pre-load provider credentials from environment variables on first
+boot. Pass them through `vane.env` or `vane.envFrom`:
+
+```yaml
+vane:
+  envFrom:
+    - secretRef:
+        name: vane-provider-keys # e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY, ...
+```
+
+Everything can also be configured later from the in-app settings screen.
+
+## Uninstalling
+
+```bash
+helm uninstall vane
+```
+
+PersistentVolumeClaims created by the chart are not deleted automatically;
+remove them manually if you no longer need the data:
+
+```bash
+kubectl delete pvc -l app.kubernetes.io/instance=vane
+```

--- a/charts/vane/templates/NOTES.txt
+++ b/charts/vane/templates/NOTES.txt
@@ -1,0 +1,46 @@
+Vane has been deployed. 🔍
+
+Release : {{ .Release.Name }}
+Variant : {{ .Values.variant }}
+Image   : {{ include "vane.image" . }}
+
+{{- if eq .Values.variant "full" }}
+
+The "full" image bundles SearXNG inside the container, so no extra search
+backend is required.
+{{- else }}
+
+You are running the "slim" image, which requires an external SearXNG instance.
+{{- if include "vane.searxng.deployed" . }}
+This chart deployed one for you and wired Vane to it at:
+  {{ include "vane.searxngUrl" . }}
+{{- else }}
+Vane is configured to use your external SearXNG instance at:
+  {{ include "vane.searxngUrl" . }}
+Make sure it has the JSON format and the Wolfram Alpha engine enabled.
+{{- end }}
+{{- end }}
+
+Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "vane.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "http://$NODE_IP:$NODE_PORT"
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           Watch its status with: kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "vane.fullname" . }}
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "vane.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo "http://$SERVICE_IP:{{ .Values.service.port }}"
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "vane.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000:3000
+  echo "Visit http://127.0.0.1:3000 to use Vane."
+{{- end }}
+
+Then open the app and finish setup (API keys, models, search backend) in the UI.

--- a/charts/vane/templates/_helpers.tpl
+++ b/charts/vane/templates/_helpers.tpl
@@ -1,0 +1,164 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vane.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec).
+*/}}
+{{- define "vane.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vane.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "vane.labels" -}}
+helm.sh/chart: {{ include "vane.chart" . }}
+{{ include "vane.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "vane.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vane.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "vane.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "vane.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the image tag from the explicit override or the variant.
+*/}}
+{{- define "vane.imageTag" -}}
+{{- if .Values.image.tag -}}
+{{- .Values.image.tag -}}
+{{- else if eq .Values.variant "slim" -}}
+slim-latest
+{{- else -}}
+latest
+{{- end -}}
+{{- end -}}
+
+{{/*
+Full image reference for the Vane container.
+*/}}
+{{- define "vane.image" -}}
+{{- printf "%s:%s" .Values.image.repository (include "vane.imageTag" .) -}}
+{{- end -}}
+
+{{/*
+Name of the in-cluster SearXNG resources.
+*/}}
+{{- define "vane.searxng.fullname" -}}
+{{- printf "%s-searxng" (include "vane.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+SearXNG selector labels.
+*/}}
+{{- define "vane.searxng.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vane.name" . }}-searxng
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+SearXNG labels.
+*/}}
+{{- define "vane.searxng.labels" -}}
+helm.sh/chart: {{ include "vane.chart" . }}
+{{ include "vane.searxng.selectorLabels" . }}
+app.kubernetes.io/component: searxng
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Whether this release deploys an in-cluster SearXNG (slim variant only).
+Returns "true" or an empty string.
+*/}}
+{{- define "vane.searxng.deployed" -}}
+{{- if and (eq .Values.variant "slim") .Values.searxng.deploy -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the SEARXNG_API_URL to inject into Vane.
+  * full   -> empty (the image bundles SearXNG at http://localhost:8080).
+  * slim + deploy -> in-cluster SearXNG service.
+  * slim + external -> the provided URL.
+*/}}
+{{- define "vane.searxngUrl" -}}
+{{- if eq .Values.variant "slim" -}}
+{{- if .Values.searxng.deploy -}}
+{{- printf "http://%s:%v" (include "vane.searxng.fullname" .) .Values.searxng.service.port -}}
+{{- else -}}
+{{- .Values.searxng.url -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the SearXNG secret_key: explicit value, previously generated value
+(kept stable across upgrades via lookup), or a freshly generated one.
+*/}}
+{{- define "vane.searxng.secretKey" -}}
+{{- if .Values.searxng.secretKey -}}
+{{- .Values.searxng.secretKey -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "vane.searxng.fullname" .) -}}
+{{- if and $existing $existing.data (index $existing.data "secretKey") -}}
+{{- index $existing.data "secretKey" | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 64 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Guardrails: validate the chosen variant / SearXNG configuration.
+*/}}
+{{- define "vane.validate" -}}
+{{- if not (or (eq .Values.variant "full") (eq .Values.variant "slim")) -}}
+{{- fail (printf "vane: `variant` must be either \"full\" or \"slim\", got %q" .Values.variant) -}}
+{{- end -}}
+{{- if eq .Values.variant "slim" -}}
+{{- if and (not .Values.searxng.deploy) (not .Values.searxng.url) -}}
+{{- fail "vane: with variant=slim you must either set searxng.deploy=true or provide searxng.url (external SearXNG instance)." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/vane/templates/deployment.yaml
+++ b/charts/vane/templates/deployment.yaml
@@ -1,0 +1,127 @@
+{{- include "vane.validate" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vane.fullname" . }}
+  labels:
+    {{- include "vane.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  {{- with .Values.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "vane.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "vane.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "vane.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: vane
+          image: {{ include "vane.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+            {{- if eq .Values.variant "full" }}
+            - name: searxng
+              containerPort: 8080
+              protocol: TCP
+            {{- end }}
+          {{- $searxngUrl := include "vane.searxngUrl" . }}
+          {{- if or $searxngUrl .Values.vane.env }}
+          env:
+            {{- if $searxngUrl }}
+            - name: SEARXNG_API_URL
+              value: {{ $searxngUrl | quote }}
+            {{- end }}
+            {{- range $key, $value := .Values.vane.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.vane.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.persistence.data.enabled }}
+            - name: data
+              mountPath: /home/vane/data
+            {{- end }}
+            {{- if .Values.persistence.uploads.enabled }}
+            - name: uploads
+              mountPath: /home/vane/uploads
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        {{- if .Values.persistence.data.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.data.existingClaim | default (printf "%s-data" (include "vane.fullname" .)) }}
+        {{- end }}
+        {{- if .Values.persistence.uploads.enabled }}
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.uploads.existingClaim | default (printf "%s-uploads" (include "vane.fullname" .)) }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/vane/templates/hpa.yaml
+++ b/charts/vane/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "vane.fullname" . }}
+  labels:
+    {{- include "vane.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "vane.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/vane/templates/ingress.yaml
+++ b/charts/vane/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "vane.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "vane.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/vane/templates/pvc.yaml
+++ b/charts/vane/templates/pvc.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "vane.fullname" . }}-data
+  labels:
+    {{- include "vane.labels" . | nindent 4 }}
+  {{- with .Values.persistence.data.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.data.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size | quote }}
+  {{- if .Values.persistence.data.storageClass }}
+  {{- if eq "-" .Values.persistence.data.storageClass }}
+  storageClassName: ''
+  {{- else }}
+  storageClassName: {{ .Values.persistence.data.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.persistence.uploads.enabled (not .Values.persistence.uploads.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "vane.fullname" . }}-uploads
+  labels:
+    {{- include "vane.labels" . | nindent 4 }}
+  {{- with .Values.persistence.uploads.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.uploads.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.uploads.size | quote }}
+  {{- if .Values.persistence.uploads.storageClass }}
+  {{- if eq "-" .Values.persistence.uploads.storageClass }}
+  storageClassName: ''
+  {{- else }}
+  storageClassName: {{ .Values.persistence.uploads.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/vane/templates/searxng-deployment.yaml
+++ b/charts/vane/templates/searxng-deployment.yaml
@@ -1,0 +1,94 @@
+{{- if include "vane.searxng.deployed" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vane.searxng.fullname" . }}
+  labels:
+    {{- include "vane.searxng.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "vane.searxng.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Roll the pod when the settings/secret change.
+        checksum/secret: {{ include (print $.Template.BasePath "/searxng-secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "vane.searxng.labels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.searxng.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: searxng
+          image: "{{ .Values.searxng.image.repository }}:{{ .Values.searxng.image.tag }}"
+          imagePullPolicy: {{ .Values.searxng.image.pullPolicy }}
+          {{- with .Values.searxng.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: SEARXNG_SETTINGS_PATH
+              value: /etc/searxng/settings.yml
+            - name: SEARXNG_PORT
+              value: '8080'
+            - name: SEARXNG_BIND_ADDRESS
+              value: 0.0.0.0
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          {{- with .Values.searxng.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/searxng/settings.yml
+              subPath: settings.yml
+              readOnly: true
+            - name: config
+              mountPath: /etc/searxng/limiter.toml
+              subPath: limiter.toml
+              readOnly: true
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "vane.searxng.fullname" . }}
+      {{- with .Values.searxng.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.searxng.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.searxng.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/vane/templates/searxng-secret.yaml
+++ b/charts/vane/templates/searxng-secret.yaml
@@ -1,0 +1,35 @@
+{{- if include "vane.searxng.deployed" . }}
+{{- $secretKey := include "vane.searxng.secretKey" . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "vane.searxng.fullname" . }}
+  labels:
+    {{- include "vane.searxng.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # Stored separately so the generated key stays stable across upgrades.
+  secretKey: {{ $secretKey | quote }}
+  limiter.toml: |
+    [botdetection.ip_limit]
+    # activate link_token method in the ip_limit method
+    link_token = true
+  settings.yml: |
+    use_default_settings: true
+
+    general:
+      instance_name: 'searxng'
+
+    search:
+      autocomplete: 'google'
+      formats:
+        - html
+        - json
+
+    server:
+      secret_key: {{ $secretKey | quote }}
+
+    engines:
+      - name: wolframalpha
+        disabled: false
+{{- end }}

--- a/charts/vane/templates/searxng-service.yaml
+++ b/charts/vane/templates/searxng-service.yaml
@@ -1,0 +1,17 @@
+{{- if include "vane.searxng.deployed" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vane.searxng.fullname" . }}
+  labels:
+    {{- include "vane.searxng.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.searxng.service.type }}
+  selector:
+    {{- include "vane.searxng.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.searxng.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/vane/templates/service.yaml
+++ b/charts/vane/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vane.fullname" . }}
+  labels:
+    {{- include "vane.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "vane.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/vane/templates/serviceaccount.yaml
+++ b/charts/vane/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vane.serviceAccountName" . }}
+  labels:
+    {{- include "vane.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/vane/templates/tests/test-connection.yaml
+++ b/charts/vane/templates/tests/test-connection.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "vane.fullname" . }}-test-connection
+  labels:
+    {{- include "vane.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: busybox:1.36
+      command: ['wget']
+      args:
+        - '--spider'
+        - '--timeout=10'
+        - 'http://{{ include "vane.fullname" . }}:{{ .Values.service.port }}/'

--- a/charts/vane/values.schema.json
+++ b/charts/vane/values.schema.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Vane Helm chart values",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["variant", "image"],
+  "properties": {
+    "variant": {
+      "type": "string",
+      "enum": ["full", "slim"],
+      "description": "Image variant to deploy: 'full' (bundles SearXNG) or 'slim' (external SearXNG)."
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository"],
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "replicaCount": { "type": "integer", "minimum": 0 },
+    "updateStrategy": { "type": "object" },
+    "vane": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "number", "boolean"]
+          }
+        },
+        "envFrom": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+    "searxng": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "deploy": { "type": "boolean" },
+        "url": { "type": "string" },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["repository"],
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string" },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          }
+        },
+        "secretKey": { "type": "string" },
+        "service": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+            },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "resources": { "type": "object" },
+        "podSecurityContext": { "type": "object" },
+        "securityContext": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" },
+        "automount": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "name": { "type": "string" }
+      }
+    },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+        },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": { "type": "string" },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": { "type": "string" },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Exact", "Prefix", "ImplementationSpecific"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "data": { "$ref": "#/definitions/persistentVolume" },
+        "uploads": { "$ref": "#/definitions/persistentVolume" }
+      }
+    },
+    "resources": { "type": "object" },
+    "livenessProbe": { "type": "object" },
+    "readinessProbe": { "type": "object" },
+    "startupProbe": { "type": "object" },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100
+        },
+        "targetMemoryUtilizationPercentage": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100
+        }
+      }
+    },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" }
+  },
+  "definitions": {
+    "persistentVolume": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "existingClaim": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadWriteOnce",
+              "ReadOnlyMany",
+              "ReadWriteMany",
+              "ReadWriteOncePod"
+            ]
+          }
+        },
+        "size": { "type": "string" },
+        "annotations": { "type": "object" }
+      }
+    }
+  }
+}

--- a/charts/vane/values.yaml
+++ b/charts/vane/values.yaml
@@ -1,0 +1,200 @@
+# Default values for the Vane Helm chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into the templates.
+
+# -- Image variant to deploy.
+#   * "full" -> deploys `itzcrazykns1337/vane:latest`, which bundles a SearXNG
+#     instance inside the same container. Nothing else is required.
+#   * "slim" -> deploys `itzcrazykns1337/vane:slim-latest`, which does NOT ship
+#     SearXNG. You must either let this chart deploy SearXNG for you
+#     (`searxng.deploy=true`) or point it at an existing instance
+#     (`searxng.url`).
+variant: full
+
+image:
+  repository: itzcrazykns1337/vane
+  # -- Overrides the image tag. When empty the tag is derived from `variant`:
+  # "full" -> "latest", "slim" -> "slim-latest".
+  tag: ''
+  pullPolicy: IfNotPresent
+
+# -- Secrets used to pull the image from a private registry.
+imagePullSecrets: []
+
+# -- Override the chart name used in resource names.
+nameOverride: ''
+# -- Override the fully qualified app name used in resource names.
+fullnameOverride: ''
+
+# -- Number of Vane replicas. Vane stores its config and history in a local
+# SQLite database on a ReadWriteOnce volume, so running more than one replica
+# is not supported unless you supply a shared ReadWriteMany volume.
+replicaCount: 1
+
+# -- Deployment update strategy. Recommend `Recreate` with the default
+# ReadWriteOnce persistence so the old pod releases the volume first.
+updateStrategy:
+  type: Recreate
+
+vane:
+  # -- Extra environment variables passed to the Vane container as key/value
+  # pairs. Useful to pre-configure providers (e.g. OPENAI_API_KEY) or to set
+  # DATA_DIR. Search backend URL is wired automatically, see `searxng`.
+  env: {}
+  #  OPENAI_API_KEY: sk-...
+  #  ANTHROPIC_API_KEY: sk-ant-...
+
+  # -- Extra environment variables sourced from existing ConfigMaps/Secrets.
+  # Rendered verbatim under the container's `envFrom`.
+  envFrom: []
+  #  - secretRef:
+  #      name: vane-provider-keys
+
+searxng:
+  # -- (slim only) Deploy a SearXNG instance in the cluster and wire it to Vane
+  # automatically. Ignored when `variant=full` (SearXNG is bundled in the image).
+  deploy: true
+  # -- (slim only) URL of an external SearXNG instance. Used when
+  # `searxng.deploy=false`. Must have JSON format and the Wolfram Alpha engine
+  # enabled.
+  url: ''
+  image:
+    repository: searxng/searxng
+    tag: latest
+    pullPolicy: IfNotPresent
+  # -- Value for SearXNG's `server.secret_key`. Leave empty to auto-generate a
+  # stable key (reused across upgrades). Set explicitly to manage it yourself.
+  secretKey: ''
+  service:
+    type: ClusterIP
+    port: 8080
+  # -- Resource requests/limits for the SearXNG container.
+  resources: {}
+  # -- Pod-level security context for the SearXNG pod.
+  podSecurityContext: {}
+  # -- Container-level security context for the SearXNG container.
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+serviceAccount:
+  # -- Whether to create a ServiceAccount for the Vane pod.
+  create: true
+  # -- Mount the API token into the pod. Vane does not talk to the Kubernetes
+  # API, so this is disabled by default.
+  automount: false
+  # -- Annotations to add to the ServiceAccount.
+  annotations: {}
+  # -- Name of the ServiceAccount. Generated from the fullname if empty.
+  name: ''
+
+# -- Additional annotations for the Vane pod.
+podAnnotations: {}
+# -- Additional labels for the Vane pod.
+podLabels: {}
+
+# -- Pod-level security context for the Vane pod. Note: the "full" image starts
+# SearXNG via sudo and therefore requires running as root, so do not force
+# runAsNonRoot when using `variant=full`.
+podSecurityContext: {}
+
+# -- Container-level security context for the Vane container.
+securityContext: {}
+
+service:
+  type: ClusterIP
+  # -- Service port that maps to Vane's HTTP port (container port 3000).
+  port: 3000
+
+ingress:
+  enabled: false
+  className: ''
+  annotations: {}
+  #  nginx.ingress.kubernetes.io/proxy-body-size: '100m'
+  hosts:
+    - host: vane.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: vane-tls
+  #    hosts:
+  #      - vane.local
+
+persistence:
+  # -- Persists Vane's config (`config.json`) and SQLite database
+  # (`db.sqlite`) at /home/vane/data.
+  data:
+    enabled: true
+    # -- Use an existing PersistentVolumeClaim instead of creating one.
+    existingClaim: ''
+    storageClass: ''
+    accessModes:
+      - ReadWriteOnce
+    size: 2Gi
+    annotations: {}
+  # -- Persists uploaded files at /home/vane/uploads.
+  uploads:
+    enabled: true
+    existingClaim: ''
+    storageClass: ''
+    accessModes:
+      - ReadWriteOnce
+    size: 5Gi
+    annotations: {}
+
+# -- Resource requests/limits for the Vane container.
+resources: {}
+#  limits:
+#    cpu: '1'
+#    memory: 2Gi
+#  requests:
+#    cpu: 500m
+#    memory: 1Gi
+
+# -- Liveness/readiness/startup probes. The startup probe is generous because
+# first boot runs database migrations (and, for the "full" image, starts the
+# bundled SearXNG).
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 6
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+startupProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 60
+
+# -- Horizontal Pod Autoscaler. Not recommended with the default local SQLite
+# persistence (see `replicaCount`).
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: null
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# -- Extra volumes to add to the Vane pod.
+extraVolumes: []
+# -- Extra volume mounts to add to the Vane container.
+extraVolumeMounts: []


### PR DESCRIPTION
## Summary

Adds a Helm chart under `charts/vane` to deploy Vane on Kubernetes. A single `variant` value selects the official image, so both published images are covered by one chart:

| `variant`        | Image                              | SearXNG                                                              |
| ---------------- | ---------------------------------- | ------------------------------------------------------------------- |
| `full` (default) | `itzcrazykns1337/vane:latest`      | bundled inside the image                                            |
| `slim`           | `itzcrazykns1337/vane:slim-latest` | deployed by the chart (`searxng.deploy=true`) or external (`searxng.url`) |

## What's included

- **Vane workload**: Deployment, Service, ServiceAccount, optional Ingress and HPA
- **Persistence**: PVCs for the config/SQLite database (`/home/vane/data`) and uploads (`/home/vane/uploads`)
- **Optional in-cluster SearXNG** (slim only): Deployment/Service/Secret generated from the repo's `searxng/settings.yml` (JSON format + Wolfram Alpha engine enabled), with a stable auto-generated `secret_key`, wired to Vane through `SEARXNG_API_URL`
- **Probes** (liveness/readiness/startup), resource limits and scheduling controls (nodeSelector/tolerations/affinity)
- **`values.schema.json`** for install-time validation of the values
- Security default: `automountServiceAccountToken: false`
- Guardrails (`fail`) for an invalid `variant` or a slim install with no search backend

## Usage

```bash
# Full image (Vane + bundled SearXNG) — recommended default
helm install vane ./charts/vane

# Slim image with a chart-managed SearXNG
helm install vane ./charts/vane --set variant=slim --set searxng.deploy=true

# Slim image with an existing SearXNG instance
helm install vane ./charts/vane \
  --set variant=slim --set searxng.deploy=false \
  --set searxng.url=http://my-searxng:8080
```

See [`charts/vane/README.md`](charts/vane/README.md) for the full list of options.

## Notes / tradeoffs

- The image tag defaults to the floating `latest` / `slim-latest` tags; override `image.tag` to pin a release such as `1.12.2` / `slim-1.12.2`.
- No enforced non-root `securityContext` by default: the `full` image starts SearXNG via `sudo` and both images run as root, so hardening is left configurable rather than forced.
- Vane stores its config and history in a local SQLite database on a `ReadWriteOnce` volume, so the chart defaults to `replicaCount: 1` with a `Recreate` strategy.

## Validation

- `helm lint` passes for `full`, `slim` + in-cluster SearXNG, and `slim` + external SearXNG
- `helm template` renders valid manifests in all three modes; the JSON schema rejects invalid values (unknown keys, wrong types, out-of-range ports, invalid variant)
- `prettier` clean — chart templates are excluded from Prettier via `.prettierignore` because Go templating conflicts with it
