### PR TITLE
Add SCRAPER_BROWSER_TYPE / SCRAPER_EXECUTABLE_PATH env vars

### DIFF
--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -13,17 +13,25 @@ class Scraper {
   private static async initBrowser() {
     await this.browserMutex.runExclusive(async () => {
       if (!this.browser) {
-        const { chromium } = await import('playwright');
-        this.browser = await chromium.launch({
+        const browserType = process.env.SCRAPER_BROWSER_TYPE || 'chromium';
+        const playwright = await import('playwright');
+        const engine = playwright[browserType as 'chromium' | 'firefox' | 'webkit'];
+        const executablePath = process.env.SCRAPER_EXECUTABLE_PATH;
+        this.browser = await engine.launch({
           headless: true,
-          channel: 'chromium-headless-shell',
-          args: [
-            '--no-sandbox',
-            '--disable-setuid-sandbox',
-            '--disable-dev-shm-usage',
-            '--disable-gpu',
-            '--disable-blink-features=AutomationControlled',
-          ],
+          ...(browserType === 'chromium'
+            ? {
+                channel: 'chromium-headless-shell',
+                args: [
+                  '--no-sandbox',
+                  '--disable-setuid-sandbox',
+                  '--disable-dev-shm-usage',
+                  '--disable-gpu',
+                  '--disable-blink-features=AutomationControlled',
+                ],
+              }
+            : {}),
+          ...(executablePath ? { executablePath } : {}),
         });
       }
 


### PR DESCRIPTION
The scraper's browser launch was hardcoded to chromium with no way to point it at a different engine or binary. Adds SCRAPER_BROWSER_TYPE (default 'chromium', unchanged behavior) and SCRAPER_EXECUTABLE_PATH, and guards the Chromium-specific channel/args behind the default case. Motivated by invisible_playwright, a Playwright wrapper around a Firefox build patched at the source level for a realistic fingerprint, useful for sites that fingerprint the scraper. Opened as draft, happy to adjust naming or scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the scraper’s browser configurable so you can choose the `playwright` engine and optionally point to a custom binary. Defaults stay the same (Chromium with current flags), so no changes needed for existing setups.

- **New Features**
  - SCRAPER_BROWSER_TYPE selects `chromium`, `firefox`, or `webkit` (default: `chromium`).
  - SCRAPER_EXECUTABLE_PATH lets you specify a custom browser executable.
  - Chromium-only channel and flags are applied only when using `chromium`.

<sup>Written for commit 14a79d7013d1b9ea61a80d9c55392a5a0f4d24de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ItzCrazyKns/Vane/pull/1159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

