### PR TITLE
Fix "is empty" crash on Anthropic: guard empty tool-call arguments

### DIFF
--- a/src/lib/models/providers/openai/openaiLLM.ts
+++ b/src/lib/models/providers/openai/openaiLLM.ts
@@ -175,13 +175,20 @@ class OpenAILLM extends BaseLLM<OpenAIConfig> {
                   arguments: tc.function?.arguments || '',
                 };
                 recievedToolCalls.push(call);
-                return { ...call, arguments: parse(call.arguments || '{}') };
+                return {
+                  ...call,
+                  arguments: parse(call.arguments.trim() || '{}'),
+                };
               } else {
                 const existingCall = recievedToolCalls[tc.index];
                 existingCall.arguments += tc.function?.arguments || '';
+                // Some providers (e.g. Anthropic's OpenAI-compatible endpoint)
+                // stream tool-call deltas where the accumulated arguments are
+                // still empty. partial-json's parse() throws " is empty" on an
+                // empty/whitespace string, so fall back to an empty object.
                 return {
                   ...existingCall,
-                  arguments: parse(existingCall.arguments),
+                  arguments: parse(existingCall.arguments.trim() || '{}'),
                 };
               }
             }) || [],


### PR DESCRIPTION
## Summary

Fixes #1160.

Every search crashes during the research phase when an Anthropic model is selected, with `Error:  is empty`.

The throw comes from `partial-json`'s `parseJSON`, which rejects empty/whitespace input (`\`${jsonString} is empty\``). In `OpenAILLM.streamText`, accumulated tool-call argument deltas are passed to `parse()`. The first delta is guarded with `|| '{}'`, but the accumulation branch is not. Anthropic's OpenAI-compatible endpoint streams a tool-call delta whose accumulated arguments are still empty when `parse()` runs, so `parse("")` throws. OpenAI/Groq always carry argument text by then, so they don't hit it.

## Change

```ts
// src/lib/models/providers/openai/openaiLLM.ts
arguments: parse(call.arguments.trim() || '{}'),
...
arguments: parse(existingCall.arguments.trim() || '{}'),
```

## Test plan

- [ ] Select an Anthropic (Claude) chat model and run a search; confirm it completes without `Error:  is empty`.
- [ ] Confirm Groq and OpenAI searches still work.