### PR TITLE
Add MiniMax provider support

### DIFF
--- a/src/lib/models/providers/index.ts
+++ b/src/lib/models/providers/index.ts
@@ -8,6 +8,7 @@ import GroqProvider from './groq';
 import LemonadeProvider from './lemonade';
 import AnthropicProvider from './anthropic';
 import LMStudioProvider from './lmstudio';
+import MiniMaxProvider from './minimax';
 
 export const providers: Record<string, ProviderConstructor<any>> = {
   openai: OpenAIProvider,
@@ -18,6 +19,7 @@ export const providers: Record<string, ProviderConstructor<any>> = {
   lemonade: LemonadeProvider,
   anthropic: AnthropicProvider,
   lmstudio: LMStudioProvider,
+  minimax: MiniMaxProvider,
 };
 
 export const getModelProvidersUIConfigSection =

--- a/src/lib/models/providers/minimax/index.ts
+++ b/src/lib/models/providers/minimax/index.ts
@@ -1,0 +1,103 @@
+import { UIConfigField } from '@/lib/config/types';
+import { getConfiguredModelProviderById } from '@/lib/config/serverRegistry';
+import { Model, ModelList, ProviderMetadata } from '../../types';
+import BaseEmbedding from '../../base/embedding';
+import BaseModelProvider from '../../base/provider';
+import BaseLLM from '../../base/llm';
+import MiniMaxLLM from './minimaxLLM';
+
+interface MiniMaxConfig {
+  apiKey: string;
+}
+
+const defaultChatModels: Model[] = [
+  {
+    name: 'MiniMax-M3',
+    key: 'MiniMax-M3',
+  },
+];
+
+const providerConfigFields: UIConfigField[] = [
+  {
+    type: 'password',
+    name: 'API Key',
+    key: 'apiKey',
+    description: 'Your MiniMax API key',
+    required: true,
+    placeholder: 'MiniMax API Key',
+    env: 'MINIMAX_API_KEY',
+    scope: 'server',
+  },
+];
+
+class MiniMaxProvider extends BaseModelProvider<MiniMaxConfig> {
+  constructor(id: string, name: string, config: MiniMaxConfig) {
+    super(id, name, config);
+  }
+
+  async getDefaultModels(): Promise<ModelList> {
+    return {
+      embedding: [],
+      chat: defaultChatModels,
+    };
+  }
+
+  async getModelList(): Promise<ModelList> {
+    const defaultModels = await this.getDefaultModels();
+    const configProvider = getConfiguredModelProviderById(this.id)!;
+
+    return {
+      embedding: [
+        ...defaultModels.embedding,
+        ...configProvider.embeddingModels,
+      ],
+      chat: [...defaultModels.chat, ...configProvider.chatModels],
+    };
+  }
+
+  async loadChatModel(key: string): Promise<BaseLLM<any>> {
+    const modelList = await this.getModelList();
+
+    const exists = modelList.chat.find((m) => m.key === key);
+
+    if (!exists) {
+      throw new Error(
+        'Error Loading MiniMax Chat Model. Invalid Model Selected',
+      );
+    }
+
+    return new MiniMaxLLM({
+      apiKey: this.config.apiKey,
+      model: key,
+      baseURL: 'https://api.minimax.io/v1',
+    });
+  }
+
+  async loadEmbeddingModel(key: string): Promise<BaseEmbedding<any>> {
+    throw new Error('MiniMax provider does not support embedding models.');
+  }
+
+  static parseAndValidate(raw: any): MiniMaxConfig {
+    if (!raw || typeof raw !== 'object')
+      throw new Error('Invalid config provided. Expected object');
+    if (!raw.apiKey)
+      throw new Error('Invalid config provided. API key must be provided');
+
+    return {
+      apiKey: String(raw.apiKey),
+    };
+  }
+
+  static getProviderConfigFields(): UIConfigField[] {
+    return providerConfigFields;
+  }
+
+  static getProviderMetadata(): ProviderMetadata {
+    return {
+      key: 'minimax',
+      name: 'MiniMax',
+    };
+  }
+}
+
+export default MiniMaxProvider;

--- a/src/lib/models/providers/minimax/minimaxLLM.ts
+++ b/src/lib/models/providers/minimax/minimaxLLM.ts
@@ -1,0 +1,5 @@
+import OpenAILLM from '../openai/openaiLLM';
+
+class MiniMaxLLM extends OpenAILLM {}
+
+export default MiniMaxLLM;


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Adds MiniMax to the model provider registry.
- Exposes MiniMax-M3 as a default chat model using MiniMax's OpenAI-compatible endpoint.

## Test plan
- Secret scan on added diff
- `corepack yarn --cwd /root/octopatch-4/work/repos/ItzCrazyKns_Vane install --immutable`
- `corepack yarn --cwd /root/octopatch-4/work/repos/ItzCrazyKns_Vane build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MiniMax as a model provider with `MiniMax-M3` as the default chat model via an OpenAI-compatible endpoint. Configure with the server env var MINIMAX_API_KEY to enable.

- **New Features**
  - Registered `minimax` in the provider registry and UI metadata.
  - Added provider config (API key, server scope, env: MINIMAX_API_KEY) with validation.
  - Implemented chat via `MiniMaxLLM` (extends OpenAI client) using baseURL https://api.minimax.io/v1; embeddings are not supported.

<sup>Written for commit c90a21f6625620d9e3bc22f915bb94f1150e6f3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ItzCrazyKns/Vane/pull/1165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

