### PR TITLE
Add MiniMax provider support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format:write": "prettier . --write"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.111.0",
     "@google/genai": "^1.34.0",
     "@headlessui/react": "^2.2.0",
     "@headlessui/tailwindcss": "^0.2.2",

--- a/src/lib/models/providers/index.ts
+++ b/src/lib/models/providers/index.ts
@@ -8,6 +8,7 @@ import GroqProvider from './groq';
 import LemonadeProvider from './lemonade';
 import AnthropicProvider from './anthropic';
 import LMStudioProvider from './lmstudio';
+import MiniMaxProvider from './minimax';
 
 export const providers: Record<string, ProviderConstructor<any>> = {
   openai: OpenAIProvider,
@@ -18,6 +19,7 @@ export const providers: Record<string, ProviderConstructor<any>> = {
   lemonade: LemonadeProvider,
   anthropic: AnthropicProvider,
   lmstudio: LMStudioProvider,
+  minimax: MiniMaxProvider,
 };
 
 export const getModelProvidersUIConfigSection =

--- a/src/lib/models/providers/minimax/index.ts
+++ b/src/lib/models/providers/minimax/index.ts
@@ -1,0 +1,154 @@
+import { UIConfigField } from '@/lib/config/types';
+import { getConfiguredModelProviderById } from '@/lib/config/serverRegistry';
+import { Model, ModelList, ProviderMetadata } from '../../types';
+import BaseEmbedding from '../../base/embedding';
+import BaseModelProvider from '../../base/provider';
+import BaseLLM from '../../base/llm';
+import MiniMaxAnthropicLLM from './minimaxAnthropicLLM';
+import MiniMaxLLM from './minimaxLLM';
+
+interface MiniMaxConfig {
+  apiKey: string;
+  baseURL: string;
+}
+
+const DEFAULT_BASE_URL = 'https://api.minimax.io/v1';
+
+const endpointOptions = [
+  {
+    name: 'Global (OpenAI)',
+    value: DEFAULT_BASE_URL,
+  },
+  {
+    name: 'Global (Anthropic)',
+    value: 'https://api.minimax.io/anthropic',
+  },
+  {
+    name: 'China (OpenAI)',
+    value: 'https://api.minimaxi.com/v1',
+  },
+  {
+    name: 'China (Anthropic)',
+    value: 'https://api.minimaxi.com/anthropic',
+  },
+];
+
+const supportedBaseURLs = new Set(
+  endpointOptions.map((endpoint) => endpoint.value),
+);
+
+const defaultChatModels: Model[] = [
+  {
+    name: 'MiniMax-M3',
+    key: 'MiniMax-M3',
+  },
+  {
+    name: 'MiniMax-M2.7',
+    key: 'MiniMax-M2.7',
+  },
+];
+
+const providerConfigFields: UIConfigField[] = [
+  {
+    type: 'password',
+    name: 'API Key',
+    key: 'apiKey',
+    description: 'Your MiniMax API key',
+    required: true,
+    placeholder: 'MiniMax API Key',
+    env: 'MINIMAX_API_KEY',
+    scope: 'server',
+  },
+  {
+    type: 'select',
+    name: 'API Endpoint',
+    key: 'baseURL',
+    description: 'Choose the MiniMax region and API protocol',
+    required: true,
+    default: DEFAULT_BASE_URL,
+    options: endpointOptions,
+    env: 'MINIMAX_BASE_URL',
+    scope: 'server',
+  },
+];
+
+class MiniMaxProvider extends BaseModelProvider<MiniMaxConfig> {
+  constructor(id: string, name: string, config: MiniMaxConfig) {
+    super(id, name, config);
+  }
+
+  async getDefaultModels(): Promise<ModelList> {
+    return {
+      embedding: [],
+      chat: defaultChatModels,
+    };
+  }
+
+  async getModelList(): Promise<ModelList> {
+    const defaultModels = await this.getDefaultModels();
+    const configProvider = getConfiguredModelProviderById(this.id)!;
+
+    return {
+      embedding: [],
+      chat: [...defaultModels.chat, ...configProvider.chatModels],
+    };
+  }
+
+  async loadChatModel(key: string): Promise<BaseLLM<any>> {
+    const modelList = await this.getModelList();
+    const exists = modelList.chat.find((model) => model.key === key);
+
+    if (!exists) {
+      throw new Error(
+        'Error Loading MiniMax Chat Model. Invalid Model Selected',
+      );
+    }
+
+    const config = {
+      apiKey: this.config.apiKey,
+      model: key,
+      baseURL: this.config.baseURL,
+    };
+
+    if (this.config.baseURL.endsWith('/anthropic')) {
+      return new MiniMaxAnthropicLLM(config);
+    }
+
+    return new MiniMaxLLM(config);
+  }
+
+  async loadEmbeddingModel(key: string): Promise<BaseEmbedding<any>> {
+    throw new Error('MiniMax provider does not support embedding models.');
+  }
+
+  static parseAndValidate(raw: any): MiniMaxConfig {
+    if (!raw || typeof raw !== 'object')
+      throw new Error('Invalid config provided. Expected object');
+    if (!raw.apiKey)
+      throw new Error('Invalid config provided. API key must be provided');
+
+    const baseURL = raw.baseURL ? String(raw.baseURL) : DEFAULT_BASE_URL;
+
+    if (!supportedBaseURLs.has(baseURL)) {
+      throw new Error('Invalid config provided. Unsupported API endpoint');
+    }
+
+    return {
+      apiKey: String(raw.apiKey),
+      baseURL,
+    };
+  }
+
+  static getProviderConfigFields(): UIConfigField[] {
+    return providerConfigFields;
+  }
+
+  static getProviderMetadata(): ProviderMetadata {
+    return {
+      key: 'minimax',
+      name: 'MiniMax',
+    };
+  }
+}
+
+export default MiniMaxProvider;

--- a/src/lib/models/providers/minimax/minimaxAnthropicLLM.ts
+++ b/src/lib/models/providers/minimax/minimaxAnthropicLLM.ts
@@ -66,33 +66,48 @@ class MiniMaxAnthropicLLM extends BaseLLM<MiniMaxAnthropicConfig> {
       .map((message) => message.content)
       .join('\n\n');
 
-    const convertedMessages = messages.flatMap<MessageParam>((message) => {
+    const convertedMessages: MessageParam[] = [];
+
+    for (let index = 0; index < messages.length; index++) {
+      const message = messages[index];
+
       if (message.role === 'system') {
-        return [];
+        continue;
       }
 
       if (message.role === 'tool') {
-        return [
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'tool_result',
-                tool_use_id: message.id,
-                content: message.content,
-              },
-            ],
-          },
-        ];
+        const content: ContentBlockParam[] = [];
+
+        while (index < messages.length && messages[index].role === 'tool') {
+          const toolMessage = messages[index];
+
+          if (toolMessage.role === 'tool') {
+            content.push({
+              type: 'tool_result',
+              tool_use_id: toolMessage.id,
+              content: toolMessage.content,
+            });
+          }
+
+          index++;
+        }
+
+        index--;
+        convertedMessages.push({ role: 'user', content });
+        continue;
       }
 
       if (message.role === 'assistant' && message.tool_calls?.length) {
-        const preservedContent = this.preservedContent.get(
-          message.tool_calls[0].id,
-        );
+        const preservedContent = message.tool_calls
+          .map((toolCall) => this.preservedContent.get(toolCall.id))
+          .find((content) => content !== undefined);
 
         if (preservedContent) {
-          return [{ role: 'assistant', content: preservedContent }];
+          convertedMessages.push({
+            role: 'assistant',
+            content: preservedContent,
+          });
+          continue;
         }
 
         const content: ContentBlockParam[] = [];
@@ -110,11 +125,15 @@ class MiniMaxAnthropicLLM extends BaseLLM<MiniMaxAnthropicConfig> {
           })),
         );
 
-        return [{ role: 'assistant', content }];
+        convertedMessages.push({ role: 'assistant', content });
+        continue;
       }
 
-      return [{ role: message.role, content: message.content }];
-    });
+      convertedMessages.push({
+        role: message.role,
+        content: message.content,
+      });
+    }
 
     return {
       messages: convertedMessages,

--- a/src/lib/models/providers/minimax/minimaxAnthropicLLM.ts
+++ b/src/lib/models/providers/minimax/minimaxAnthropicLLM.ts
@@ -1,0 +1,353 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type {
+  ContentBlock,
+  ContentBlockParam,
+  MessageCreateParamsBase,
+  MessageParam,
+  RawMessageStreamEvent,
+  Tool as AnthropicTool,
+} from '@anthropic-ai/sdk/resources/messages';
+import { repairJson } from '@toolsycc/json-repair';
+import { Message } from '@/lib/types';
+import { parse } from 'partial-json';
+import z from 'zod';
+import BaseLLM from '../../base/llm';
+import {
+  GenerateObjectInput,
+  GenerateOptions,
+  GenerateTextInput,
+  GenerateTextOutput,
+  StreamTextOutput,
+  ToolCall,
+} from '../../types';
+
+type MiniMaxAnthropicConfig = {
+  apiKey: string;
+  model: string;
+  baseURL: string;
+  options?: GenerateOptions;
+};
+
+type ConvertedMessages = {
+  messages: MessageParam[];
+  system?: string;
+};
+
+type StreamingToolCall = {
+  argumentsJson: string;
+  id: string;
+  name: string;
+};
+
+const toArguments = (value: unknown): Record<string, any> => {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, any>;
+  }
+
+  return {};
+};
+
+class MiniMaxAnthropicLLM extends BaseLLM<MiniMaxAnthropicConfig> {
+  private anthropicClient: Anthropic;
+  private preservedContent = new Map<string, ContentBlockParam[]>();
+
+  constructor(protected config: MiniMaxAnthropicConfig) {
+    super(config);
+
+    this.anthropicClient = new Anthropic({
+      apiKey: this.config.apiKey,
+      baseURL: this.config.baseURL,
+    });
+  }
+
+  private convertMessages(messages: Message[]): ConvertedMessages {
+    const system = messages
+      .filter((message) => message.role === 'system')
+      .map((message) => message.content)
+      .join('\n\n');
+
+    const convertedMessages = messages.flatMap<MessageParam>((message) => {
+      if (message.role === 'system') {
+        return [];
+      }
+
+      if (message.role === 'tool') {
+        return [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: message.id,
+                content: message.content,
+              },
+            ],
+          },
+        ];
+      }
+
+      if (message.role === 'assistant' && message.tool_calls?.length) {
+        const preservedContent = this.preservedContent.get(
+          message.tool_calls[0].id,
+        );
+
+        if (preservedContent) {
+          return [{ role: 'assistant', content: preservedContent }];
+        }
+
+        const content: ContentBlockParam[] = [];
+
+        if (message.content) {
+          content.push({ type: 'text', text: message.content });
+        }
+
+        content.push(
+          ...message.tool_calls.map((toolCall) => ({
+            type: 'tool_use' as const,
+            id: toolCall.id,
+            name: toolCall.name,
+            input: toolCall.arguments,
+          })),
+        );
+
+        return [{ role: 'assistant', content }];
+      }
+
+      return [{ role: message.role, content: message.content }];
+    });
+
+    return {
+      messages: convertedMessages,
+      ...(system ? { system } : {}),
+    };
+  }
+
+  private convertTools(input: GenerateTextInput): AnthropicTool[] | undefined {
+    if (!input.tools?.length) {
+      return undefined;
+    }
+
+    return input.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      input_schema: z.toJSONSchema(tool.schema) as AnthropicTool.InputSchema,
+    }));
+  }
+
+  private createParams(input: GenerateTextInput): MessageCreateParamsBase {
+    const convertedMessages = this.convertMessages(input.messages);
+
+    return {
+      model: this.config.model,
+      messages: convertedMessages.messages,
+      max_tokens:
+        input.options?.maxTokens ?? this.config.options?.maxTokens ?? 8192,
+      system: convertedMessages.system,
+      tools: this.convertTools(input),
+      temperature:
+        input.options?.temperature ?? this.config.options?.temperature ?? 1,
+      top_p: input.options?.topP ?? this.config.options?.topP,
+      stop_sequences:
+        input.options?.stopSequences ?? this.config.options?.stopSequences,
+    };
+  }
+
+  private rememberContent(content: ContentBlock[]): void {
+    const requestContent = content.flatMap<ContentBlockParam>((block) => {
+      if (block.type === 'text') {
+        return [{ type: 'text', text: block.text }];
+      }
+
+      if (block.type === 'thinking') {
+        return [
+          {
+            type: 'thinking',
+            thinking: block.thinking,
+            signature: block.signature,
+          },
+        ];
+      }
+
+      if (block.type === 'redacted_thinking') {
+        return [{ type: 'redacted_thinking', data: block.data }];
+      }
+
+      if (block.type === 'tool_use') {
+        return [
+          {
+            type: 'tool_use',
+            id: block.id,
+            name: block.name,
+            input: block.input,
+          },
+        ];
+      }
+
+      return [];
+    });
+    const toolCallIds = requestContent
+      .filter((block) => block.type === 'tool_use')
+      .map((block) => block.id);
+
+    toolCallIds.forEach((id) => this.preservedContent.set(id, requestContent));
+
+    while (this.preservedContent.size > 100) {
+      const oldestKey = this.preservedContent.keys().next().value;
+
+      if (!oldestKey) {
+        break;
+      }
+
+      this.preservedContent.delete(oldestKey);
+    }
+  }
+
+  async generateText(input: GenerateTextInput): Promise<GenerateTextOutput> {
+    const response = await this.anthropicClient.messages.create({
+      ...this.createParams(input),
+      stream: false,
+    });
+
+    this.rememberContent(response.content);
+
+    const content = response.content
+      .filter((block) => block.type === 'text')
+      .map((block) => block.text)
+      .join('');
+    const toolCalls = response.content
+      .filter((block) => block.type === 'tool_use')
+      .map<ToolCall>((block) => ({
+        id: block.id,
+        name: block.name,
+        arguments: toArguments(block.input),
+      }));
+
+    return {
+      content,
+      toolCalls,
+      additionalInfo: {
+        finishReason: response.stop_reason,
+      },
+    };
+  }
+
+  async *streamText(
+    input: GenerateTextInput,
+  ): AsyncGenerator<StreamTextOutput> {
+    const stream = this.anthropicClient.messages.stream(
+      this.createParams(input),
+    );
+    const toolCalls = new Map<number, StreamingToolCall>();
+    let finishReason: string | null = null;
+    let doneEmitted = false;
+
+    for await (const event of stream as AsyncIterable<RawMessageStreamEvent>) {
+      if (
+        event.type === 'content_block_start' &&
+        event.content_block.type === 'tool_use'
+      ) {
+        const toolCall = {
+          argumentsJson: '',
+          id: event.content_block.id,
+          name: event.content_block.name,
+        };
+
+        toolCalls.set(event.index, toolCall);
+        yield {
+          contentChunk: '',
+          toolCallChunk: [
+            {
+              id: toolCall.id,
+              name: toolCall.name,
+              arguments: toArguments(event.content_block.input),
+            },
+          ],
+        };
+      } else if (
+        event.type === 'content_block_delta' &&
+        event.delta.type === 'text_delta'
+      ) {
+        yield {
+          contentChunk: event.delta.text,
+          toolCallChunk: [],
+        };
+      } else if (
+        event.type === 'content_block_delta' &&
+        event.delta.type === 'input_json_delta'
+      ) {
+        const toolCall = toolCalls.get(event.index);
+
+        if (!toolCall) {
+          continue;
+        }
+
+        toolCall.argumentsJson += event.delta.partial_json;
+
+        try {
+          yield {
+            contentChunk: '',
+            toolCallChunk: [
+              {
+                id: toolCall.id,
+                name: toolCall.name,
+                arguments: toArguments(parse(toolCall.argumentsJson)),
+              },
+            ],
+          };
+        } catch {
+          continue;
+        }
+      } else if (event.type === 'message_delta') {
+        finishReason = event.delta.stop_reason;
+        doneEmitted = finishReason !== null;
+        yield {
+          contentChunk: '',
+          toolCallChunk: [],
+          done: doneEmitted,
+          additionalInfo: {
+            finishReason,
+          },
+        };
+      } else if (event.type === 'message_stop' && !doneEmitted) {
+        yield {
+          contentChunk: '',
+          toolCallChunk: [],
+          done: true,
+          additionalInfo: {
+            finishReason,
+          },
+        };
+      }
+    }
+
+    this.rememberContent((await stream.finalMessage()).content);
+  }
+
+  async generateObject<T>(input: GenerateObjectInput): Promise<T> {
+    const response = await this.generateText(input);
+
+    return input.schema.parse(
+      JSON.parse(
+        repairJson(response.content, {
+          extractJson: true,
+        }) as string,
+      ),
+    ) as T;
+  }
+
+  async *streamObject<T>(input: GenerateObjectInput): AsyncGenerator<T> {
+    let receivedObject = '';
+
+    for await (const chunk of this.streamText(input)) {
+      receivedObject += chunk.contentChunk;
+
+      try {
+        yield parse(receivedObject) as T;
+      } catch {
+        continue;
+      }
+    }
+  }
+}
+
+export default MiniMaxAnthropicLLM;

--- a/src/lib/models/providers/minimax/minimaxLLM.ts
+++ b/src/lib/models/providers/minimax/minimaxLLM.ts
@@ -20,7 +20,9 @@ class MiniMaxLLM extends OpenAILLM {
           return message;
         }
 
-        const content = this.preservedContent.get(message.tool_calls[0].id);
+        const content = message.tool_calls
+          .map((toolCall) => this.preservedContent.get(toolCall.id))
+          .find((preservedContent) => preservedContent !== undefined);
         return content ? { ...message, content } : message;
       }),
     };

--- a/src/lib/models/providers/minimax/minimaxLLM.ts
+++ b/src/lib/models/providers/minimax/minimaxLLM.ts
@@ -1,0 +1,76 @@
+import OpenAILLM from '../openai/openaiLLM';
+import {
+  GenerateTextInput,
+  GenerateTextOutput,
+  StreamTextOutput,
+} from '../../types';
+
+class MiniMaxLLM extends OpenAILLM {
+  private preservedContent = new Map<string, string>();
+
+  private withPreservedContent(input: GenerateTextInput): GenerateTextInput {
+    return {
+      ...input,
+      messages: input.messages.map((message) => {
+        if (
+          message.role !== 'assistant' ||
+          message.content ||
+          !message.tool_calls?.length
+        ) {
+          return message;
+        }
+
+        const content = this.preservedContent.get(message.tool_calls[0].id);
+        return content ? { ...message, content } : message;
+      }),
+    };
+  }
+
+  private rememberContent(toolCallIds: string[], content: string): void {
+    if (!content || toolCallIds.length === 0) {
+      return;
+    }
+
+    toolCallIds.forEach((id) => this.preservedContent.set(id, content));
+
+    while (this.preservedContent.size > 100) {
+      const oldestKey = this.preservedContent.keys().next().value;
+
+      if (!oldestKey) {
+        break;
+      }
+
+      this.preservedContent.delete(oldestKey);
+    }
+  }
+
+  async generateText(input: GenerateTextInput): Promise<GenerateTextOutput> {
+    const response = await super.generateText(this.withPreservedContent(input));
+
+    this.rememberContent(
+      response.toolCalls.map((toolCall) => toolCall.id),
+      response.content,
+    );
+
+    return response;
+  }
+
+  async *streamText(
+    input: GenerateTextInput,
+  ): AsyncGenerator<StreamTextOutput> {
+    let content = '';
+    const toolCallIds = new Set<string>();
+
+    for await (const chunk of super.streamText(
+      this.withPreservedContent(input),
+    )) {
+      content += chunk.contentChunk;
+      chunk.toolCallChunk.forEach((toolCall) => toolCallIds.add(toolCall.id));
+      yield chunk;
+    }
+
+    this.rememberContent([...toolCallIds], content);
+  }
+}
+
+export default MiniMaxLLM;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,14 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@anthropic-ai/sdk@^0.111.0":
+  version "0.111.0"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.111.0.tgz#fa8dbd8aaabf3b53e08bc9942361cab369740444"
+  integrity sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==
+  dependencies:
+    json-schema-to-ts "^3.1.1"
+    standardwebhooks "^1.0.0"
+
 "@asamuzakjp/css-color@^5.1.5":
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-5.1.8.tgz#b61d5b6852fb1c835b35b483191e32b529da859d"
@@ -145,6 +153,11 @@
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
+"@babel/runtime@^7.18.3":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
 "@babel/template@^7.28.6":
   version "7.28.6"
@@ -1106,6 +1119,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
+
+"@stablelib/base64@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-1.0.1.tgz#bdfc1c6d3a62d7a3b7bbc65b6cce1bb4561641be"
+  integrity sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==
 
 "@swc/helpers@0.5.15":
   version "0.5.15"
@@ -2979,6 +2997,11 @@ fast-png@^6.2.0:
     iobuffer "^5.3.2"
     pako "^2.1.0"
 
+fast-sha256@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-sha256/-/fast-sha256-1.3.0.tgz#7916ba2054eeb255982608cccd0f6660c79b7ae6"
+  integrity sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==
+
 fastq@^1.6.0:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.20.1.tgz#ca750a10dc925bc8b18839fd203e3ef4b3ced675"
@@ -3911,6 +3934,14 @@ json-diff@0.9.0:
     cli-color "^2.0.0"
     difflib "~0.2.1"
     dreamopt "~0.8.0"
+
+json-schema-to-ts@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz#81f3acaf5a34736492f6f5f51870ef9ece1ca853"
+  integrity sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    ts-algebra "^2.0.0"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -5400,6 +5431,14 @@ stackblur-canvas@^2.0.0:
   resolved "https://registry.yarnpkg.com/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz#af931277d0b5096df55e1f91c530043e066989b6"
   integrity sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==
 
+standardwebhooks@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/standardwebhooks/-/standardwebhooks-1.0.0.tgz#5faa23ceacbf9accd344361101d9e3033b64324f"
+  integrity sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==
+  dependencies:
+    "@stablelib/base64" "^1.0.0"
+    fast-sha256 "^1.3.0"
+
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz#f481ff70a548f6124d0312c3aa14cbfa7aa542ad"
@@ -5794,6 +5833,11 @@ trim-repeated@^1.0.0:
   integrity sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==
   dependencies:
     escape-string-regexp "^1.0.2"
+
+ts-algebra@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-2.0.0.tgz#4e3e0953878f26518fce7f6bb115064a65388b7a"
+  integrity sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==
 
 ts-api-utils@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
## Summary
- Register MiniMax with MiniMax-M3 and MiniMax-M2.7 as default chat models.
- Expose the global and China OpenAI-compatible and Anthropic-compatible endpoints through provider configuration.
- Preserve complete assistant content across tool-call turns and keep embedding models disabled.

## Validation
- `corepack yarn tsc --noEmit`
- `corepack yarn build`
- `corepack yarn prettier src/lib/models/providers/index.ts src/lib/models/providers/minimax/index.ts src/lib/models/providers/minimax/minimaxLLM.ts src/lib/models/providers/minimax/minimaxAnthropicLLM.ts package.json --check`
- `corepack yarn check --integrity`
- Captured OpenAI-compatible and Anthropic-compatible request URLs for both regions.
- Verified parallel tool-result grouping and preserved-content lookup with focused conversion checks.

Changed-file ESLint could not start because the repository's current ESLint configuration fails to load with a circular-structure error.
