### PR TITLE
docs: refresh Sealos deployment link

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Vane runs on Next.js and handles all API requests. It works right away on the sa
 
 ## One-Click Deployment
 
-[![Deploy to Sealos](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://usw.sealos.io/?openapp=system-template%3FtemplateName%3Dperplexica)
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/perplexica)
 [![Deploy to RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/?app_id=267)
 [![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=U11MRQ8U9RM4&openapp=system-fastdeploy%3FtemplateName%3Dperplexica)
 [![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/vps/docker-hosting?compose_url=https://raw.githubusercontent.com/ItzCrazyKns/Vane/refs/heads/master/docker-compose.yaml)


### PR DESCRIPTION
## Summary

- refresh the existing Sealos deployment entry introduced in #655
- point the button to the public Sealos App Store page
- use the provider-owned badge asset

The diff is README-only. Application code and the default installation flow remain unchanged.

## Deployment verification

I tested the proposed Sealos template revision on 2026-07-27 with:

- Vane `v1.12.2` using the upstream slim image
- a separate SearXNG service
- first-run setup with an OpenAI-compatible provider
- a cited web answer
- a WolframAlpha calculation (`2 + 2 = 4`)
- image and video search results
- persisted conversation history

The deployment stayed healthy during the validation window.

- App Store: https://sealos.io/products/app-store/perplexica
- Tested template update: https://github.com/labring-actions/templates/pull/732

## Operational notes

The template provisions a `1Gi` persistent volume for `/home/vane/data` and the Transformers cache, covering SQLite data, provider configuration, uploads, and downloaded embedding models.

Provider credentials are entered through Sealos deployment parameters or Vane settings. Secret values stay outside the Vane repository.

Vane `v1.12.2` currently exposes the application without an account or authentication layer. Anyone with the public URL can use configured providers, change settings, and view stored conversations. The template README recommends an authenticated gateway, private network, or equivalent access policy before sharing the deployment.

I can maintain this deployment path and follow up when the template or documentation needs an update.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Sealos one‑click deploy badge to use the provider‑hosted asset and links it to the public Sealos App Store page. Docs-only change; no application code or installation flow changes.

<sup>Written for commit c76fc8abd41614df8e5c0adf87b9c25403b63853. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ItzCrazyKns/Vane/pull/1175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

