### PR TITLE
fix: guard partial-json parse against empty tool-call arguments

### DIFF
--- a/src/lib/models/providers/openai/openaiLLM.ts
+++ b/src/lib/models/providers/openai/openaiLLM.ts
@@ -181,7 +181,9 @@ class OpenAILLM extends BaseLLM<OpenAIConfig> {
                 existingCall.arguments += tc.function?.arguments || '';
                 return {
                   ...existingCall,
-                  arguments: parse(existingCall.arguments),
+                  arguments: existingCall.arguments.trim()
+                    ? parse(existingCall.arguments)
+                    : {},
                 };
               }
             }) || [],


### PR DESCRIPTION
## Problem

Every search query ends stuck on "Brainstorming..." forever. The backend logs show:

```
Error:  is empty
    at i (.next/server/chunks/403.js:8:64257)   // partial-json parse
    at q.streamText (...)
    at async i.research (...)
    at async m.searchAsync (.../api/chat/route.js)
```

## Root cause

`streamText` in `src/lib/models/providers/openai/openaiLLM.ts` parses streaming tool-call arguments with `partial-json` on **every** delta chunk:

```ts
const existingCall = recievedToolCalls[tc.index];
existingCall.arguments += tc.function?.arguments || "";
return { ...existingCall, arguments: parse(existingCall.arguments) };
```

When a tool call has no arguments (the research agent finishes by calling `done`, whose schema is `{}`), the accumulated string is `""` and `partial-json` throws `` Error(`${jsonString} is empty`) ``. The research stream dies and the UI hangs. The same happens when a provider emits a first delta with the tool name/id and empty arguments followed by an arguments-less delta.

## Fix

Only call `parse` when the accumulated arguments are non-empty; otherwise yield `{}` (an empty-arguments tool call legitimately has no arguments):

```ts
arguments: existingCall.arguments.trim()
  ? parse(existingCall.arguments)
  : {},
```

The first-chunk branch already guards with `parse(call.arguments || "{}")`; the `streamObject` sites are already wrapped in try/catch. This was the only unguarded path.

## Verification

Reproduced via `POST /api/chat` on a stock `slim-latest` image (error at the research→`done` transition), then confirmed the full flow completes after the patch: search queries → results → `researchComplete` → answer stream with citations → `messageEnd`. Applies equally to GitHub master (same code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash during streaming tool-call parsing that left searches stuck on “Brainstorming...”. We now parse arguments only when non-empty and use {} for empty calls like `done`.

- **Bug Fixes**
  - Guard `partial-json` parsing in `src/lib/models/providers/openai/openaiLLM.ts`; parse only when the accumulated arguments are non-empty, otherwise use {}.
  - Prevents `Error:  is empty` from aborting the research stream so search → research → answer completes.

<sup>Written for commit 43102e59a75f8e9d023136f77c2cc34c7be979af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ItzCrazyKns/Vane/pull/1176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

