### PR TITLE
fix: don't submit message on IME composition Enter key

### DIFF
--- a/src/components/EmptyChatMessageInput.tsx
+++ b/src/components/EmptyChatMessageInput.tsx
@@ -47,7 +47,8 @@ const EmptyChatMessageInput = () => {
         setMessage('');
       }}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
+        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && e.keyCode !== 229
+        ) {
           e.preventDefault();
           sendMessage(message);
           setMessage('');

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -54,7 +54,8 @@ const MessageInput = () => {
         setMessage('');
       }}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' && !e.shiftKey && !loading) {
+        if (e.key === 'Enter' && !e.shiftKey && !loading && !e.nativeEvent.isComposing && e.keyCode !== 229
+        ) {
           e.preventDefault();
           sendMessage(message);
           setMessage('');


### PR DESCRIPTION
## Summary
- Pressing Enter to confirm IME (Japanese/Chinese/Korean) composition was submitting the chat message prematurely, because the keydown handlers only checked `e.key === 'Enter'`.
- Added a guard using `e.nativeEvent.isComposing` (plus a `keyCode !== 229` fallback for browsers that don't clear `isComposing` in time) in both the home-screen input and the in-chat follow-up input.

## Test plan
- [x] Verified in a running instance that pressing Enter during IME composition no longer submits the message, while a normal Enter after composition still sends it, in both `EmptyChatMessageInput` and `MessageInput`.

🤖 [Claude Codeで生成されました](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent messages from sending when pressing Enter to confirm IME composition (Japanese/Chinese/Korean). Adds a guard in `EmptyChatMessageInput` and `MessageInput` to ignore Enter while composing using `e.nativeEvent.isComposing` with a `keyCode !== 229` fallback; normal Enter still sends.

<sup>Written for commit ce8d9e5500fef17fb277415c35cc9266b7a4daaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ItzCrazyKns/Vane/pull/1181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

