### PR TITLE
Modernize setup wizard, fix setup-complete persistence and light-mode

### DIFF
--- a/src/components/DeleteChat.tsx
+++ b/src/components/DeleteChat.tsx
@@ -88,7 +88,7 @@ const DeleteChat = ({
                 leaveTo="opacity-0 scale-95"
               >
                 <DialogPanel className="w-full max-w-md transform rounded-2xl bg-light-secondary dark:bg-dark-secondary border border-light-200 dark:border-dark-200 p-6 text-left align-middle shadow-xl transition-all">
-                  <DialogTitle className="text-lg font-medium leading-6 dark:text-white">
+                  <DialogTitle className="text-lg font-medium leading-6 text-black dark:text-white">
                     Delete Confirmation
                   </DialogTitle>
                   <Description className="text-sm dark:text-white/70 text-black/70">

--- a/src/components/Discover/MajorNewsCard.tsx
+++ b/src/components/Discover/MajorNewsCard.tsx
@@ -28,7 +28,7 @@ const MajorNewsCard = ({
         </div>
         <div className="flex flex-col justify-center flex-1 py-4">
           <h2
-            className="text-3xl font-light mb-3 leading-tight line-clamp-3 group-hover:text-cyan-500 dark:group-hover:text-cyan-300 transition duration-200"
+            className="text-3xl font-light mb-3 leading-tight line-clamp-3 text-black dark:text-white group-hover:text-cyan-500 dark:group-hover:text-cyan-300 transition duration-200"
             style={{ fontFamily: 'PP Editorial, serif' }}
           >
             {item.title}
@@ -42,7 +42,7 @@ const MajorNewsCard = ({
       <>
         <div className="flex flex-col justify-center flex-1 py-4">
           <h2
-            className="text-3xl font-light mb-3 leading-tight line-clamp-3 group-hover:text-cyan-500 dark:group-hover:text-cyan-300 transition duration-200"
+            className="text-3xl font-light mb-3 leading-tight line-clamp-3 text-black dark:text-white group-hover:text-cyan-500 dark:group-hover:text-cyan-300 transition duration-200"
             style={{ fontFamily: 'PP Editorial, serif' }}
           >
             {item.title}

--- a/src/components/Discover/SmallNewsCard.tsx
+++ b/src/components/Discover/SmallNewsCard.tsx
@@ -19,7 +19,7 @@ const SmallNewsCard = ({ item }: { item: Discover }) => (
       />
     </div>
     <div className="p-4">
-      <h3 className="font-semibold text-sm mb-2 leading-tight line-clamp-2 group-hover:text-cyan-500 dark:group-hover:text-cyan-300 transition duration-200">
+      <h3 className="font-semibold text-sm mb-2 leading-tight line-clamp-2 text-black dark:text-white group-hover:text-cyan-500 dark:group-hover:text-cyan-300 transition duration-200">
         {item.title}
       </h3>
       <p className="text-black/60 dark:text-white/60 text-xs leading-relaxed line-clamp-2">

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -73,7 +73,7 @@ const MessageInput = () => {
         onHeightChange={(height, props) => {
           setTextareaRows(Math.ceil(height / props.rowHeight));
         }}
-        className="transition bg-transparent dark:placeholder:text-white/50 placeholder:text-sm text-sm dark:text-white resize-none focus:outline-none w-full px-2 max-h-24 lg:max-h-36 xl:max-h-48 flex-grow flex-shrink"
+        className="transition bg-transparent placeholder:text-sm text-sm text-black dark:text-white dark:placeholder:text-white/50 resize-none focus:outline-none w-full px-2 max-h-24 lg:max-h-36 xl:max-h-48 flex-grow flex-shrink"
         placeholder="Ask a follow-up"
       />
       {mode === 'single' && (

--- a/src/components/MessageSources.tsx
+++ b/src/components/MessageSources.tsx
@@ -32,7 +32,7 @@ const MessageSources = ({ sources }: { sources: Chunk[] }) => {
           href={source.metadata.url}
           target="_blank"
         >
-          <p className="dark:text-white text-xs overflow-hidden whitespace-nowrap text-ellipsis">
+          <p className="text-black dark:text-white text-xs overflow-hidden whitespace-nowrap text-ellipsis">
             {source.metadata.title}
           </p>
           <div className="flex flex-row items-center justify-between">
@@ -108,7 +108,7 @@ const MessageSources = ({ sources }: { sources: Chunk[] }) => {
                 leaveTo="opacity-0 scale-95"
               >
                 <DialogPanel className="w-full max-w-md transform rounded-2xl bg-light-secondary dark:bg-dark-secondary border border-light-200 dark:border-dark-200 p-6 text-left align-middle shadow-xl transition-all">
-                  <DialogTitle className="text-lg font-medium leading-6 dark:text-white">
+                  <DialogTitle className="text-lg font-medium leading-6 text-black dark:text-white">
                     Sources
                   </DialogTitle>
                   <div className="grid grid-cols-2 gap-2 overflow-auto max-h-[300px] mt-2 pr-2">
@@ -119,7 +119,7 @@ const MessageSources = ({ sources }: { sources: Chunk[] }) => {
                         href={source.metadata.url}
                         target="_blank"
                       >
-                        <p className="dark:text-white text-xs overflow-hidden whitespace-nowrap text-ellipsis">
+                        <p className="text-black dark:text-white text-xs overflow-hidden whitespace-nowrap text-ellipsis">
                           {source.metadata.title}
                         </p>
                         <div className="flex flex-row items-center justify-between">

--- a/src/components/SearchImages.tsx
+++ b/src/components/SearchImages.tsx
@@ -66,7 +66,7 @@ const SearchImages = ({
             );
             setLoading(false);
           }}
-          className="border border-dashed border-light-200 dark:border-dark-200 hover:bg-light-200 dark:hover:bg-dark-200 active:scale-95 duration-200 transition px-4 py-2 flex flex-row items-center justify-between rounded-lg dark:text-white text-sm w-full"
+          className="border border-dashed border-light-200 dark:border-dark-200 hover:bg-light-200 dark:hover:bg-dark-200 active:scale-95 duration-200 transition px-4 py-2 flex flex-row items-center justify-between rounded-lg text-black dark:text-white text-sm w-full"
         >
           <div className="flex flex-row items-center space-x-2">
             <ImagesIcon size={17} />

--- a/src/components/SearchVideos.tsx
+++ b/src/components/SearchVideos.tsx
@@ -83,7 +83,7 @@ const Searchvideos = ({
             );
             setLoading(false);
           }}
-          className="border border-dashed border-light-200 dark:border-dark-200 hover:bg-light-200 dark:hover:bg-dark-200 active:scale-95 duration-200 transition px-4 py-2 flex flex-row items-center justify-between rounded-lg dark:text-white text-sm w-full"
+          className="border border-dashed border-light-200 dark:border-dark-200 hover:bg-light-200 dark:hover:bg-dark-200 active:scale-95 duration-200 transition px-4 py-2 flex flex-row items-center justify-between rounded-lg text-black dark:text-white text-sm w-full"
         >
           <div className="flex flex-row items-center space-x-2">
             <VideoIcon size={17} />

--- a/src/components/Setup/SetupConfig.tsx
+++ b/src/components/Setup/SetupConfig.tsx
@@ -70,7 +70,7 @@ const SetupConfig = ({
     visibleProviders.filter((p) => p.chatModels.length > 0).length > 0;
 
   return (
-    <div className="w-[95vw] md:w-[80vw] lg:w-[65vw] mx-auto px-2 sm:px-4 md:px-6 flex flex-col space-y-6">
+    <div className="w-full mx-auto flex flex-col space-y-6">
       {setupState === 2 && (
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -79,7 +79,7 @@ const SetupConfig = ({
             y: 0,
             transition: { duration: 0.5, delay: 0.1 },
           }}
-          className="w-full h-[calc(95vh-80px)] bg-light-primary dark:bg-dark-primary border border-light-200 dark:border-dark-200 rounded-xl shadow-sm flex flex-col overflow-hidden"
+          className="w-full h-[min(58vh,540px)] bg-light-primary dark:bg-dark-primary border border-light-200 dark:border-dark-200 rounded-xl shadow-sm flex flex-col overflow-hidden"
         >
           <div className="flex-1 overflow-y-auto px-3 sm:px-4 md:px-6 py-4 md:py-6">
             <div className="flex flex-row justify-between items-center mb-4 md:mb-6 pb-3 md:pb-4 border-b border-light-200 dark:border-dark-200">
@@ -140,7 +140,7 @@ const SetupConfig = ({
             y: 0,
             transition: { duration: 0.5, delay: 0.1 },
           }}
-          className="w-full h-[calc(95vh-80px)] bg-light-primary dark:bg-dark-primary border border-light-200 dark:border-dark-200 rounded-xl shadow-sm flex flex-col overflow-hidden"
+          className="w-full h-[min(58vh,540px)] bg-light-primary dark:bg-dark-primary border border-light-200 dark:border-dark-200 rounded-xl shadow-sm flex flex-col overflow-hidden"
         >
           <div className="flex-1 overflow-y-auto px-3 sm:px-4 md:px-6 py-4 md:py-6">
             <div className="flex flex-row justify-between items-center mb-4 md:mb-6 pb-3 md:pb-4 border-b border-light-200 dark:border-dark-200">
@@ -162,8 +162,22 @@ const SetupConfig = ({
         </motion.div>
       )}
 
-      <div className="flex flex-row items-center justify-between pt-2">
-        <a></a>
+      <div className="flex flex-row items-center justify-end pt-2">
+        {setupState === 3 && (
+          <motion.button
+            initial={{ opacity: 0, x: -10 }}
+            animate={{
+              opacity: 1,
+              x: 0,
+              transition: { duration: 0.5 },
+            }}
+            onClick={() => setSetupState(2)}
+            className="mr-auto flex flex-row items-center gap-1.5 md:gap-2 px-3 md:px-4 py-2 md:py-2.5 rounded-lg text-xs sm:text-sm font-medium text-black/60 dark:text-white/60 hover:text-black dark:hover:text-white hover:bg-light-200 dark:hover:bg-dark-200 transition-all duration-200"
+          >
+            <ArrowLeft className="w-4 h-4 md:w-[18px] md:h-[18px]" />
+            <span>Back</span>
+          </motion.button>
+        )}
         {setupState === 2 && (
           <motion.button
             initial={{ opacity: 0, x: 10 }}

--- a/src/components/Setup/SetupWizard.tsx
+++ b/src/components/Setup/SetupWizard.tsx
@@ -1,124 +1,145 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { UIConfigSections } from '@/lib/config/types';
 import { AnimatePresence, motion } from 'framer-motion';
+import { ArrowRight } from 'lucide-react';
 import SetupConfig from './SetupConfig';
+
+const STEPS = ['Welcome', 'Connections', 'Models'] as const;
+
+const ease: [number, number, number, number] = [0.16, 1, 0.3, 1];
 
 const SetupWizard = ({
   configSections,
 }: {
   configSections: UIConfigSections;
 }) => {
-  const [showWelcome, setShowWelcome] = useState(true);
-  const [showSetup, setShowSetup] = useState(false);
   const [setupState, setSetupState] = useState(1);
+  const setupRef = useRef<HTMLDivElement | null>(null);
 
-  const delay = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-
+  /* The step wrapper keeps a constant key, so it does not remount when the
+  user moves between Connections and Models (remounting would reset
+  SetupConfig's provider state). That also means the enter animation only runs
+  once, so onAnimationComplete cannot move focus on later step changes. Move
+  focus here instead so keyboard users do not lose it when the previous step's
+  controls unmount. The initial 1 -> 2 mount is handled by onAnimationComplete
+  (the wrapper mounts only after the intro's exit completes). */
   useEffect(() => {
-    (async () => {
-      await delay(2500);
-      setShowWelcome(false);
-      await delay(600);
-      setShowSetup(true);
-      setSetupState(1);
-      await delay(1500);
-      setSetupState(2);
-    })();
-  }, []);
+    if (setupState <= 1) return;
+    setupRef.current?.focus();
+  }, [setupState]);
 
   return (
-    <div className="bg-light-primary dark:bg-dark-primary h-screen w-screen fixed inset-0 overflow-hidden">
-      <AnimatePresence>
-        {showWelcome && (
-          <div className="absolute inset-0 flex items-center justify-center overflow-hidden">
-            <motion.div
-              className="absolute flex flex-col items-center justify-center h-full"
-              initial={{ opacity: 1 }}
-              exit={{ opacity: 0, scale: 1.1 }}
-              transition={{ duration: 0.6 }}
-            >
-              <motion.h2
-                transition={{ duration: 0.6 }}
-                initial={{ opacity: 0, translateY: '30px' }}
-                animate={{ opacity: 1, translateY: '0px' }}
-                className="text-4xl md:text-6xl xl:text-8xl font-normal font-['Instrument_Serif'] tracking-tight"
-              >
-                Welcome to
-                <span className="text-[#24A0ED] italic font-['PP_Editorial']">
-                  Vane
-                </span>
-              </motion.h2>
-              <motion.p
-                transition={{ delay: 0.8, duration: 0.7 }}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                className="text-black/70 dark:text-white/70 text-sm md:text-lg xl:text-2xl mt-2"
-              >
-                <span className="font-light">Web search,</span>{' '}
-                <span className="font-light font-['PP_Editorial'] italic">
-                  reimagined
-                </span>
-              </motion.p>
-            </motion.div>
-            <motion.div
-              initial={{ opacity: 0, scale: 0.5 }}
-              animate={{
-                opacity: 0.2,
-                scale: 1,
-                transition: { delay: 0.8, duration: 0.7 },
-              }}
-              exit={{ opacity: 0, scale: 1.1, transition: { duration: 0.6 } }}
-              className="bg-[#24A0ED] left-50 translate-x-[-50%] h-[250px] w-[250px] rounded-full relative z-40 blur-[100px]"
-            />
-          </div>
-        )}
-        {showSetup && (
-          <div className="absolute inset-0 flex items-center justify-center overflow-hidden">
-            <AnimatePresence mode="wait">
-              {setupState === 1 && (
-                <motion.p
-                  key="setup-text"
-                  transition={{ duration: 0.6 }}
-                  initial={{ opacity: 0, translateY: '30px' }}
-                  animate={{ opacity: 1, translateY: '0px' }}
-                  exit={{
-                    opacity: 0,
-                    translateY: '-30px',
-                    transition: { duration: 0.6 },
-                  }}
-                  className="text-2xl md:text-4xl xl:text-6xl font-normal font-['Instrument_Serif'] tracking-tight"
+    <div className="bg-light-primary dark:bg-dark-primary fixed inset-0 overflow-y-auto">
+      <div className="min-h-full flex flex-col">
+        {/* Wordmark + step progress */}
+        <header className="shrink-0 flex flex-col items-center pt-6 md:pt-10 select-none">
+          <span className="text-sm md:text-base font-semibold tracking-tight text-black dark:text-white">
+            Vane<span className="text-[#24A0ED]">.</span>
+          </span>
+
+          <div
+            className="w-full max-w-[320px] px-6 mt-6 md:mt-8"
+            role="progressbar"
+            aria-valuemin={1}
+            aria-valuemax={STEPS.length}
+            aria-valuenow={setupState}
+            aria-label={`Step ${setupState} of ${STEPS.length}: ${STEPS[setupState - 1]}`}
+          >
+            <div className="grid grid-cols-3 gap-1.5">
+              {STEPS.map((label, index) => (
+                <div
+                  key={label}
+                  className={`h-1 rounded-full transition-colors duration-500 ${
+                    index + 1 <= setupState
+                      ? 'bg-[#24A0ED]'
+                      : 'bg-light-200 dark:bg-dark-200'
+                  }`}
+                />
+              ))}
+            </div>
+            <div className="grid grid-cols-3 gap-1.5 mt-2">
+              {STEPS.map((label, index) => (
+                <span
+                  key={label}
+                  className={`text-center text-[10px] font-medium uppercase tracking-widest transition-colors duration-500 ${
+                    index + 1 <= setupState
+                      ? 'text-black/70 dark:text-white/70'
+                      : 'text-black/60 dark:text-white/60'
+                  }`}
                 >
-                  Let us get
-                  <span className="text-[#24A0ED] italic font-['PP_Editorial']">
-                    Vane
-                  </span>{' '}
-                  set up for you
-                </motion.p>
-              )}
-              {setupState > 1 && (
-                <motion.div
-                  key="setup-config"
-                  initial={{ opacity: 0, translateY: '30px' }}
-                  animate={{
-                    opacity: 1,
-                    translateY: '0px',
-                    transition: { duration: 0.6 },
-                  }}
-                >
-                  <SetupConfig
-                    configSections={configSections}
-                    setupState={setupState}
-                    setSetupState={setSetupState}
-                  />
-                </motion.div>
-              )}
-            </AnimatePresence>
+                  {label}
+                </span>
+              ))}
+            </div>
           </div>
-        )}
-      </AnimatePresence>
+        </header>
+
+        {/* Step content */}
+        <main className="flex-1 flex items-center justify-center w-full px-4 sm:px-6 py-6 md:py-10">
+          <AnimatePresence mode="wait" initial={false}>
+            {setupState === 1 ? (
+              <motion.div
+                key="intro"
+                initial={{ opacity: 0, y: 12 }}
+                animate={{
+                  opacity: 1,
+                  y: 0,
+                  transition: { duration: 0.5, ease },
+                }}
+                exit={{
+                  opacity: 0,
+                  y: -12,
+                  transition: { duration: 0.3, ease },
+                }}
+                className="flex flex-col items-center text-center max-w-sm"
+              >
+                <h1 className="text-3xl md:text-4xl font-semibold tracking-tight text-black dark:text-white">
+                  Welcome to
+                  <span className="text-[#24A0ED]"> Vane</span>
+                </h1>
+                <p className="mt-3 text-sm md:text-base text-black/60 dark:text-white/60">
+                  Web search, reimagined. Connect a model provider to finish
+                  setting up.
+                </p>
+                <button
+                  onClick={() => setSetupState(2)}
+                  className="group mt-8 inline-flex items-center gap-2 rounded-lg bg-[#24A0ED] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#1e8fd1] active:scale-[0.98] transition-all duration-150"
+                >
+                  Get started
+                  <ArrowRight className="w-4 h-4 transition-transform duration-150 group-hover:translate-x-0.5" />
+                </button>
+              </motion.div>
+            ) : (
+              <motion.div
+                key="setup"
+                ref={setupRef}
+                tabIndex={-1}
+                initial={{ opacity: 0, y: 16 }}
+                animate={{
+                  opacity: 1,
+                  y: 0,
+                  transition: { duration: 0.5, ease },
+                }}
+                exit={{
+                  opacity: 0,
+                  y: -16,
+                  transition: { duration: 0.3, ease },
+                }}
+                onAnimationComplete={() => setupRef.current?.focus()}
+                className="w-full max-w-[46rem] focus:outline-none"
+              >
+                <SetupConfig
+                  configSections={configSections}
+                  setupState={setupState}
+                  setSetupState={setSetupState}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </main>
+      </div>
     </div>
   );
 };

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -21,7 +21,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           ref={ref}
           disabled={disabled || loading}
           className={cn(
-            'bg-light-secondary dark:bg-dark-secondary px-3 py-2 flex items-center overflow-hidden border border-light-200 dark:border-dark-200 dark:text-white rounded-lg appearance-none w-full pr-10 text-xs lg:text-sm',
+            'bg-light-secondary text-black dark:bg-dark-secondary px-3 py-2 flex items-center overflow-hidden border border-light-200 dark:border-dark-200 dark:text-white rounded-lg appearance-none w-full pr-10 text-xs lg:text-sm',
             className,
           )}
         >

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -145,13 +145,24 @@ class ConfigManager {
       this.configPath,
       JSON.stringify(this.currentConfig, null, 2),
     );
+
+    /* Invalidate the mtime-keyed cache: filesystems with coarse timestamp
+    granularity can report the same mtimeMs for successive writes, which would
+    make the stale cached snapshot look current. */
+    this.persistedCache = null;
   }
 
   private normalizeConfig(raw: any): Config {
     const isRecord = (v: any): v is Record<string, any> =>
       v !== null && typeof v === 'object' && !Array.isArray(v);
 
+    /* Spread the raw object first so unknown persisted top-level fields
+    (e.g. written by a newer version or generic settings) survive the
+    normalize -> syncFromDisk -> saveConfig round trip, instead of being
+    dropped by a fixed literal on the next mutation. Known keys are still
+    validated below. */
     return {
+      ...(isRecord(raw) ? raw : {}),
       version: raw.version ?? this.configVersion,
       setupComplete: raw.setupComplete === true,
       preferences: isRecord(raw.preferences) ? raw.preferences : {},
@@ -168,6 +179,11 @@ class ConfigManager {
     };
   }
 
+  private parseConfigFromDisk(): Config {
+    const raw = JSON.parse(fs.readFileSync(this.configPath, 'utf-8'));
+    return this.normalizeConfig(raw);
+  }
+
   private readPersistedConfig(): Config {
     const stat = fs.statSync(this.configPath);
 
@@ -175,8 +191,7 @@ class ConfigManager {
       return this.persistedCache.config;
     }
 
-    const raw = JSON.parse(fs.readFileSync(this.configPath, 'utf-8'));
-    const config = this.normalizeConfig(raw);
+    const config = this.parseConfigFromDisk();
     this.persistedCache = { mtimeMs: stat.mtimeMs, config };
     return config;
   }
@@ -185,9 +200,12 @@ class ConfigManager {
   serialize a stale copy (e.g. dropping providers added by other bundles or
   resetting setupComplete to false). Read failures propagate: mutating a
   snapshot while the persisted file is unreadable risks overwriting newer
-  state, so callers surface the error instead. */
+  state, so callers surface the error instead.
+
+  The result is cloned so in-place mutations made by callers cannot poison
+  the shared persistedCache object when a subsequent writeFileSync fails. */
   private syncFromDisk() {
-    this.currentConfig = this.readPersistedConfig();
+    this.currentConfig = JSON.parse(JSON.stringify(this.readPersistedConfig()));
   }
 
   private initializeConfig() {
@@ -433,12 +451,14 @@ class ConfigManager {
   public isSetupComplete() {
     /* Route handlers and pages are bundled separately by Next.js, so this
     module-level singleton is a different instance in layout.tsx than in
-    /api/config/setup-complete. Read the persisted value from disk (cached by
-    file mtime) instead of the in-memory copy so the wizard is dismissed once
-    the API route marks setup as complete. Read/parse failures propagate so a
-    corrupted config surfaces as a server error instead of silently rendering
-    the setup wizard. */
-    return this.readPersistedConfig().setupComplete === true;
+    /api/config/setup-complete. Read directly from disk (never from the
+    mtime-keyed cache) so the wizard is dismissed once the API route marks
+    setup as complete: cache keys can collide when the filesystem reports the
+    same mtimeMs for successive writes. This is a correctness-critical read,
+    so the per-request parse is intentional. Read/parse failures propagate so
+    a corrupted config surfaces as a server error instead of silently
+    rendering the setup wizard. */
+    return this.parseConfigFromDisk().setupComplete === true;
   }
 
   public markSetupComplete() {

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -20,6 +20,10 @@ class ConfigManager {
       searxngURL: '',
     },
   };
+  /* Cached parse of the persisted config, keyed by file mtime. Lets repeated
+  reads (e.g. isSetupComplete on every layout render) avoid blocking disk
+  I/O while still picking up writes made by other Next.js route bundles. */
+  private persistedCache: { mtimeMs: number; config: Config } | null = null;
   uiConfigSections: UIConfigSections = {
     preferences: [
       {
@@ -126,10 +130,64 @@ class ConfigManager {
   }
 
   private saveConfig() {
+    /* If the persisted config cannot be read, its contents are unknown.
+    Overwriting it with the in-memory snapshot could silently destroy newer
+    settings (or another bundle's updates), so let the error propagate and
+    abort the write. Route handlers wrap these calls and map the failure to
+    their existing 500 response. */
+    const latest = this.readPersistedConfig();
+    /* Other Next.js bundles may have marked setup complete after this
+    instance last loaded the config. Never downgrade true -> false. */
+    this.currentConfig.setupComplete =
+      latest.setupComplete || this.currentConfig.setupComplete;
+
     fs.writeFileSync(
       this.configPath,
       JSON.stringify(this.currentConfig, null, 2),
     );
+  }
+
+  private normalizeConfig(raw: any): Config {
+    const isRecord = (v: any): v is Record<string, any> =>
+      v !== null && typeof v === 'object' && !Array.isArray(v);
+
+    return {
+      version: raw.version ?? this.configVersion,
+      setupComplete: raw.setupComplete === true,
+      preferences: isRecord(raw.preferences) ? raw.preferences : {},
+      personalization: isRecord(raw.personalization) ? raw.personalization : {},
+      modelProviders: Array.isArray(raw.modelProviders)
+        ? raw.modelProviders
+        : [],
+      search: isRecord(raw.search)
+        ? {
+            searxngURL: '',
+            ...raw.search,
+          }
+        : { searxngURL: '' },
+    };
+  }
+
+  private readPersistedConfig(): Config {
+    const stat = fs.statSync(this.configPath);
+
+    if (this.persistedCache && this.persistedCache.mtimeMs === stat.mtimeMs) {
+      return this.persistedCache.config;
+    }
+
+    const raw = JSON.parse(fs.readFileSync(this.configPath, 'utf-8'));
+    const config = this.normalizeConfig(raw);
+    this.persistedCache = { mtimeMs: stat.mtimeMs, config };
+    return config;
+  }
+
+  /* Refresh in-memory state from disk before mutating so writes never
+  serialize a stale copy (e.g. dropping providers added by other bundles or
+  resetting setupComplete to false). Read failures propagate: mutating a
+  snapshot while the persisted file is unreadable risks overwriting newer
+  state, so callers surface the error instead. */
+  private syncFromDisk() {
+    this.currentConfig = this.readPersistedConfig();
   }
 
   private initializeConfig() {
@@ -255,6 +313,8 @@ class ConfigManager {
     const parts = key.split('.');
     if (parts.length === 0) return;
 
+    this.syncFromDisk();
+
     let target: any = this.currentConfig;
     for (let i = 0; i < parts.length - 1; i++) {
       const part = parts[i];
@@ -272,6 +332,8 @@ class ConfigManager {
   }
 
   public addModelProvider(type: string, name: string, config: any) {
+    this.syncFromDisk();
+
     const newModelProvider: ConfigModelProvider = {
       id: crypto.randomUUID(),
       name,
@@ -289,6 +351,7 @@ class ConfigManager {
   }
 
   public removeModelProvider(id: string) {
+    this.syncFromDisk();
     const index = this.currentConfig.modelProviders.findIndex(
       (p) => p.id === id,
     );
@@ -302,6 +365,7 @@ class ConfigManager {
   }
 
   public async updateModelProvider(id: string, name: string, config: any) {
+    this.syncFromDisk();
     const provider = this.currentConfig.modelProviders.find((p) => {
       return p.id === id;
     });
@@ -321,6 +385,7 @@ class ConfigManager {
     type: 'embedding' | 'chat',
     model: any,
   ) {
+    this.syncFromDisk();
     const provider = this.currentConfig.modelProviders.find(
       (p) => p.id === providerId,
     );
@@ -345,6 +410,7 @@ class ConfigManager {
     type: 'embedding' | 'chat',
     modelKey: string,
   ) {
+    this.syncFromDisk();
     const provider = this.currentConfig.modelProviders.find(
       (p) => p.id === providerId,
     );
@@ -365,10 +431,18 @@ class ConfigManager {
   }
 
   public isSetupComplete() {
-    return this.currentConfig.setupComplete;
+    /* Route handlers and pages are bundled separately by Next.js, so this
+    module-level singleton is a different instance in layout.tsx than in
+    /api/config/setup-complete. Read the persisted value from disk (cached by
+    file mtime) instead of the in-memory copy so the wizard is dismissed once
+    the API route marks setup as complete. Read/parse failures propagate so a
+    corrupted config surfaces as a server error instead of silently rendering
+    the setup wizard. */
+    return this.readPersistedConfig().setupComplete === true;
   }
 
   public markSetupComplete() {
+    this.syncFromDisk();
     if (!this.currentConfig.setupComplete) {
       this.currentConfig.setupComplete = true;
     }

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -202,9 +202,15 @@ class ConfigManager {
   snapshot while the persisted file is unreadable risks overwriting newer
   state, so callers surface the error instead.
 
-  The result is cloned so in-place mutations made by callers cannot poison
-  the shared persistedCache object when a subsequent writeFileSync fails. */
+  The cache is cleared before reading so synchronization always starts from
+  the actual file bytes: a mutation that aborts without writing (e.g. an
+  unknown provider id) used to leave the mtime-keyed entry in place, and on a
+  coarse-timestamp filesystem another bundle's write can report the same
+  mtimeMs and be shadowed by that stale cached snapshot. The result is also
+  cloned so in-place mutations made by callers cannot poison the shared
+  persistedCache object when a subsequent writeFileSync fails. */
   private syncFromDisk() {
+    this.persistedCache = null;
     this.currentConfig = JSON.parse(JSON.stringify(this.readPersistedConfig()));
   }
 


### PR DESCRIPTION
Summary

Modernizes the first-run onboarding and fixes two bugs discovered while testing it: the setup wizard not being dismissed after completing setup, and UI text rendering white/unreadable in light mode.

Changes

**Setup wizard redesign** (`SetupWizard.tsx`, `SetupConfig.tsx`)
- Replaced the cinematic timed splash with a clean, minimal multi-step flow — Vercel/Perplexity-style: wordmark, segmented step indicator (Welcome → Connections → Models), and a user-paced "Get started" CTA
- Removed the auto-playing 2.5s welcome + 1.5s teaser delays
- Constrained setup panels from full-screen (`95vw` × `95vh`) to a contained card (`min(58vh, 540px)` height, ~46rem max width)
- Added Back navigation on the Models step
- Softened motion to short, subtle fades instead of heavy 30px slides and blur blobs

**Bug fix: setup wizard re-appears after completion** (`src/lib/config/index.ts`)
- *Root cause:* Next.js App Router bundles route handlers and pages separately, so the module-level `configManager` singleton is a different in-memory instance in `layout.tsx` vs `/api/config/setup-complete`. `markSetupComplete()` updated the handler's instance and wrote `setupComplete: true` to disk, but the layout's instance still returned the stale `false` — so the wizard showed again after reload.
- *Fix:* `isSetupComplete()` now reads the persisted value from `data/config.json` instead of the in-memory copy.

**Bug fix: unreadable white text in light mode** (7 files)
- Components that only declared `dark:text-white` (or had no text color at all) rendered white/invisible in light mode
- Added paired `text-black` / `dark:text-white` colors to: `MessageInput` ("Ask a follow-up"), `MessageSources` (source titles + dialog), `DeleteChat` (dialog title), `SearchImages`/`SearchVideos` toggles, `MajorNewsCard`/`SmallNewsCard` titles (these had no base color at all — also fixed dark mode)

## Testing

- `npx tsc --noEmit` passes
- Manual: completing setup now lands in the app; light mode shows dark, readable text across chat, sources, dialogs, and Discover cards

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernizes the first-run setup wizard and fixes setup-complete persistence and light-mode text.

**Setup wizard**
- Replaces the timed splash with a user-paced Welcome → Connections → Models flow, a step indicator, and Back navigation on the Models step.
- Setup panels are now a contained card instead of nearly full-screen, and motion is limited to short fades.

**Bug Fixes**
- The config manager now reads setup completion directly from disk and clears its cached snapshot before syncing from disk on every mutation, so the wizard stays dismissed after setup and writes never overwrite newer changes.
- Config writes preserve unknown top-level fields and fail if the persisted config can't be read.
- Text that was only styled for dark mode now has a `text-black` fallback across chat, sources, dialogs, Discover cards, and setup controls.

<sup>Written for commit ea1cd6a5870e5f1cbbaa6f5da256c33360d2af05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ItzCrazyKns/Vane/pull/1192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

