### PR TITLE
feat(providers): add llmman as a local model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Want to know more about its architecture and how it works? You can read it [here
 
 ## ✨ Features
 
-🤖 **Support for all major AI providers** - Use local LLMs through Ollama or connect to OpenAI, Anthropic Claude, Google Gemini, Groq, and more. Mix and match models based on your needs.
+🤖 **Support for all major AI providers** - Use local LLMs through Ollama or [llmman](https://github.com/llmmanorg/llmman) or connect to OpenAI, Anthropic Claude, Google Gemini, Groq, and more. Mix and match models based on your needs.
 
 ⚡ **Smart search modes** - Choose Speed Mode when you need quick answers, Balanced Mode for everyday searches, or Quality Mode for deep research.
 
@@ -176,6 +176,10 @@ If you're encountering an Ollama connection error, it is likely due to the backe
    - Inside `/etc/systemd/system/ollama.service`, you need to add `Environment="OLLAMA_HOST=0.0.0.0:11434"`. (Change the port number if you are using a different one.) Then reload the systemd manager configuration with `systemctl daemon-reload`, and restart Ollama by `systemctl restart ollama`. For more information see [Ollama docs](https://github.com/ollama/ollama/blob/main/docs/faq.md#setting-environment-variables-on-linux)
 
    - Ensure that the port (default is 11434) is not blocked by your firewall.
+
+#### llmman Connection Errors
+
+[llmman](https://github.com/llmmanorg/llmman) serves the Ollama API on port `17434`, so the steps above apply with `17434` in place of `11434`. To expose it to Docker, start it with `LLMMAN_HOST=0.0.0.0:17434 llmman serve`.
 
 #### Lemonade Connection Errors
 

--- a/src/lib/models/providers/index.ts
+++ b/src/lib/models/providers/index.ts
@@ -8,6 +8,7 @@ import GroqProvider from './groq';
 import LemonadeProvider from './lemonade';
 import AnthropicProvider from './anthropic';
 import LMStudioProvider from './lmstudio';
+import LlmmanProvider from './llmman';
 
 export const providers: Record<string, ProviderConstructor<any>> = {
   openai: OpenAIProvider,
@@ -18,6 +19,7 @@ export const providers: Record<string, ProviderConstructor<any>> = {
   lemonade: LemonadeProvider,
   anthropic: AnthropicProvider,
   lmstudio: LMStudioProvider,
+  llmman: LlmmanProvider,
 };
 
 export const getModelProvidersUIConfigSection =

--- a/src/lib/models/providers/llmman/index.ts
+++ b/src/lib/models/providers/llmman/index.ts
@@ -1,0 +1,36 @@
+import { UIConfigField } from '@/lib/config/types';
+import { ProviderMetadata } from '../../types';
+import OllamaProvider from '../ollama';
+
+// llmman (https://github.com/llmmanorg/llmman) serves the Ollama API on port
+// 17434, so only the config fields and metadata differ from OllamaProvider.
+
+const providerConfigFields: UIConfigField[] = [
+  {
+    type: 'string',
+    name: 'Base URL',
+    key: 'baseURL',
+    description: 'The base URL for llmman',
+    required: true,
+    placeholder: process.env.DOCKER
+      ? 'http://host.docker.internal:17434'
+      : 'http://localhost:17434',
+    env: 'LLMMAN_BASE_URL',
+    scope: 'server',
+  },
+];
+
+class LlmmanProvider extends OllamaProvider {
+  static getProviderConfigFields(): UIConfigField[] {
+    return providerConfigFields;
+  }
+
+  static getProviderMetadata(): ProviderMetadata {
+    return {
+      key: 'llmman',
+      name: 'llmman',
+    };
+  }
+}
+
+export default LlmmanProvider;


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- `src/lib/models/providers/llmman/index.ts`: `LlmmanProvider` subclasses `OllamaProvider`, overriding only the config fields (default `http://localhost:17434` / `http://host.docker.internal:17434`, env `LLMMAN_BASE_URL`) and provider metadata. Listing, chat and embeddings are inherited.
- `src/lib/models/providers/index.ts`: registers `llmman` so it appears in the settings UI.
- `README.md`: mentions llmman next to Ollama and adds a short troubleshooting note about port `17434`.
- Inherited connection/validation error strings still say "Ollama"; happy to override them if preferred.

**Testing:** `npm install --legacy-peer-deps --ignore-scripts` then `npx tsc --noEmit` passes; `prettier --check` is clean on the two `.ts` files. Not run against a live llmman server.

> AI-assisted, reviewed before submitting.
